### PR TITLE
fix: CI 테스트 7건 실패 수정

### DIFF
--- a/src/main/java/com/min/chalkakserver/ChalkakServerApplication.java
+++ b/src/main/java/com/min/chalkakserver/ChalkakServerApplication.java
@@ -2,11 +2,13 @@ package com.min.chalkakserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableCaching
 @EnableScheduling
 public class ChalkakServerApplication {
 

--- a/src/main/java/com/min/chalkakserver/config/cache/RedisCacheConfig.java
+++ b/src/main/java/com/min/chalkakserver/config/cache/RedisCacheConfig.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
-@EnableCaching
 @Profile("!test")
 public class RedisCacheConfig implements CachingConfigurer {
     

--- a/src/main/java/com/min/chalkakserver/config/cache/RedisCacheConfig.java
+++ b/src/main/java/com/min/chalkakserver/config/cache/RedisCacheConfig.java
@@ -10,6 +10,7 @@ import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -25,6 +26,7 @@ import java.util.Map;
 
 @Configuration
 @EnableCaching
+@Profile("!test")
 public class RedisCacheConfig implements CachingConfigurer {
     
     @Value("${spring.redis.host}")

--- a/src/main/java/com/min/chalkakserver/service/CacheService.java
+++ b/src/main/java/com/min/chalkakserver/service/CacheService.java
@@ -18,7 +18,7 @@ public class CacheService {
     @Autowired
     private CacheManager cacheManager;
     
-    @Autowired
+    @Autowired(required = false)
     private RedisTemplate<String, Object> redisTemplate;
 
     public void evictCache(String cacheName) {
@@ -50,7 +50,7 @@ public class CacheService {
                 cacheStats.put("type", cache.getClass().getSimpleName());
                 
                 // Redis 통계 정보
-                Set<String> keys = redisTemplate.keys(cacheName + "::*");
+                Set<String> keys = redisTemplate != null ? redisTemplate.keys(cacheName + "::*") : null;
                 if (keys != null) {
                     cacheStats.put("size", keys.size());
                     cacheStats.put("keys", keys);

--- a/src/test/java/com/min/chalkakserver/controller/CongestionControllerTest.java
+++ b/src/test/java/com/min/chalkakserver/controller/CongestionControllerTest.java
@@ -132,6 +132,8 @@ class CongestionControllerTest {
     void submitCongestionReport_ValidRequest_ShouldReturn200() throws Exception {
         CongestionReportRequestDto request = CongestionReportRequestDto.builder()
                 .congestionLevel(CongestionReport.CongestionLevel.NORMAL)
+                .latitude(37.5665)
+                .longitude(126.9780)
                 .build();
 
         CongestionReportResponseDto response = CongestionReportResponseDto.builder()
@@ -164,6 +166,8 @@ class CongestionControllerTest {
     void submitCongestionReport_Duplicate_ShouldReturn409() throws Exception {
         CongestionReportRequestDto request = CongestionReportRequestDto.builder()
                 .congestionLevel(CongestionReport.CongestionLevel.BUSY)
+                .latitude(37.5665)
+                .longitude(126.9780)
                 .build();
 
         given(congestionService.submitReport(any(), eq(10L), any()))

--- a/src/test/java/com/min/chalkakserver/service/AuthServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/AuthServiceTest.java
@@ -7,6 +7,7 @@ import com.min.chalkakserver.entity.User.AuthProvider;
 import com.min.chalkakserver.exception.AuthException;
 import com.min.chalkakserver.repository.CongestionReportRepository;
 import com.min.chalkakserver.repository.FavoriteRepository;
+import com.min.chalkakserver.repository.PhotoBoothReportRepository;
 import com.min.chalkakserver.repository.RefreshTokenRepository;
 import com.min.chalkakserver.repository.ReviewRepository;
 import com.min.chalkakserver.repository.UserRepository;
@@ -42,6 +43,7 @@ class AuthServiceTest {
     @Mock private ReviewRepository reviewRepository;
     @Mock private FavoriteRepository favoriteRepository;
     @Mock private CongestionReportRepository congestionReportRepository;
+    @Mock private PhotoBoothReportRepository photoBoothReportRepository;
     @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private SocialAuthService socialAuthService;
     @Mock private PasswordEncoder passwordEncoder;
@@ -363,10 +365,12 @@ class AuthServiceTest {
 
             // then - 순서 검증
             var inOrder = inOrder(reviewRepository, favoriteRepository,
-                    congestionReportRepository, refreshTokenRepository, userRepository);
+                    congestionReportRepository, photoBoothReportRepository,
+                    refreshTokenRepository, userRepository);
             inOrder.verify(reviewRepository).deleteAllByUser(testUser);
             inOrder.verify(favoriteRepository).deleteAllByUser(testUser);
             inOrder.verify(congestionReportRepository).deleteAllByUser(testUser);
+            inOrder.verify(photoBoothReportRepository).deleteAllByUser(testUser);
             inOrder.verify(refreshTokenRepository).deleteAllByUser(testUser);
             inOrder.verify(userRepository).delete(testUser);
         }

--- a/src/test/java/com/min/chalkakserver/service/CongestionServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/CongestionServiceTest.java
@@ -237,9 +237,18 @@ class CongestionServiceTest {
     private CongestionReportRequestDto buildRequest(CongestionReport.CongestionLevel level) {
         CongestionReportRequestDto request = new CongestionReportRequestDto();
         try {
-            Field field = CongestionReportRequestDto.class.getDeclaredField("congestionLevel");
-            field.setAccessible(true);
-            field.set(request, level);
+            Field congestionField = CongestionReportRequestDto.class.getDeclaredField("congestionLevel");
+            congestionField.setAccessible(true);
+            congestionField.set(request, level);
+
+            Field latField = CongestionReportRequestDto.class.getDeclaredField("latitude");
+            latField.setAccessible(true);
+            latField.set(request, 37.5);
+
+            Field lonField = CongestionReportRequestDto.class.getDeclaredField("longitude");
+            lonField.setAccessible(true);
+            lonField.set(request, 127.0);
+
             return request;
         } catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Closes #6

## 변경 내용

### CongestionControllerTest / CongestionServiceTest (4건)
- `CongestionReportRequestDto`에 `latitude/longitude` 필드 추가 후 테스트 미반영
- 테스트 요청 객체에 `latitude`, `longitude` 값 추가

### AuthServiceTest (1건)
- `AuthService.deleteAccount()`에 `photoBoothReportRepository` 의존성 추가 후 테스트 미반영
- `@Mock PhotoBoothReportRepository` 추가 및 `inOrder` 검증 반영

### PhotoBoothServiceCacheTest (2건)
- CI에 Redis 미설치로 `RedisCacheConfig`의 Redis 연결 실패
- `RedisCacheConfig`에 `@Profile("!test")` 추가하여 test profile에서 제외
- `CacheService`의 `RedisTemplate` 주입을 `required=false`로 변경