### PR TITLE
feat: 앱인토스 토스 로그인 연동 추가

### DIFF
--- a/src/main/java/com/min/chalkakserver/dto/auth/SocialLoginRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/SocialLoginRequestDto.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class SocialLoginRequestDto {
 
     @NotBlank(message = "Provider is required")
-    @Pattern(regexp = "^(kakao|naver|apple)$", message = "Provider must be kakao, naver, or apple")
+    @Pattern(regexp = "^(kakao|naver|apple|toss)$", message = "Provider must be kakao, naver, apple, or toss")
     private String provider;
 
     @NotBlank(message = "Access token is required")

--- a/src/main/java/com/min/chalkakserver/entity/User.java
+++ b/src/main/java/com/min/chalkakserver/entity/User.java
@@ -116,7 +116,7 @@ public class User {
     }
 
     public enum AuthProvider {
-        KAKAO, NAVER, APPLE, EMAIL
+        KAKAO, NAVER, APPLE, EMAIL, TOSS
     }
 
     public enum Role {

--- a/src/main/java/com/min/chalkakserver/service/SocialAuthService.java
+++ b/src/main/java/com/min/chalkakserver/service/SocialAuthService.java
@@ -47,6 +47,7 @@ public class SocialAuthService {
             case "kakao" -> getKakaoUserInfo(accessToken);
             case "naver" -> getNaverUserInfo(accessToken);
             case "apple" -> getAppleUserInfo(accessToken);
+            case "toss" -> getTossUserInfo(accessToken);
             default -> throw new AuthException("Unsupported provider: " + provider);
         };
     }
@@ -123,6 +124,42 @@ public class SocialAuthService {
         } catch (Exception e) {
             log.error("Failed to get Naver user info: {}", e.getMessage());
             throw new AuthException("Failed to get Naver user info");
+        }
+    }
+
+    /**
+     * 토스 앱인토스 사용자 정보 처리
+     * 앱인토스 미니앱은 토스 앱 내에서만 실행되며, mTLS로 통신이 보호됩니다.
+     * accessToken 필드에 JSON 형태의 토스 사용자 정보를 전달받습니다.
+     * 형식: {"userId":"toss-user-id","name":"이름","profileImageUrl":"url"}
+     */
+    private SocialUserInfo getTossUserInfo(String tossUserData) {
+        try {
+            JsonNode jsonNode = objectMapper.readTree(tossUserData);
+
+            String id = jsonNode.get("userId").asText();
+            if (id == null || id.isBlank()) {
+                throw new AuthException("Toss userId is required");
+            }
+
+            String name = jsonNode.has("name") ? jsonNode.get("name").asText() : null;
+            String profileImageUrl = jsonNode.has("profileImageUrl")
+                ? jsonNode.get("profileImageUrl").asText() : null;
+
+            log.info("Toss user info retrieved: id={}", id);
+
+            return SocialUserInfo.builder()
+                .id(id)
+                .email(null)  // 토스는 이메일을 제공하지 않음
+                .nickname(name)
+                .profileImageUrl(profileImageUrl)
+                .build();
+
+        } catch (AuthException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Failed to parse Toss user info: {}", e.getMessage());
+            throw new AuthException("Failed to parse Toss user info");
         }
     }
 


### PR DESCRIPTION
## Summary
- AuthProvider enum에 TOSS 추가
- SocialLoginRequestDto 검증에 toss provider 추가
- SocialAuthService에 토스 사용자 정보 파싱 메서드 추가

## 토스 로그인 흐름
토스 미니앱 → Toss SDK 사용자 정보 → `POST /api/auth/login {provider:"toss"}` → JWT 발급

## 변경 파일
- `User.java` - AuthProvider enum에 TOSS 추가
- `SocialLoginRequestDto.java` - 검증 regex에 toss 추가
- `SocialAuthService.java` - getTossUserInfo() 메서드 추가

## 비고
- DB 스키마 변경 없음
- 앱인토스 mTLS로 통신 보호

Closes #8