### PR TITLE
feat: add app and report stats endpoints

### DIFF
--- a/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
+++ b/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 // 인증 관련 엔드포인트 허용
                 .requestMatchers("/api/auth/login", "/api/auth/login/email", "/api/auth/register", "/api/auth/refresh", "/api/auth/logout").permitAll()
+                // 앱 통계 요약은 앱 정보 화면에서 비로그인 사용자도 조회 가능
+                .requestMatchers(HttpMethod.GET, "/api/stats/summary").permitAll()
                 // 사진관 제보 현황은 인증 필요 (wildcard보다 먼저 선언)
                 .requestMatchers(HttpMethod.GET, "/api/photo-booths/reports/**").authenticated()
                 // 포토부스 조회 API는 인증 없이 허용 (GET만)

--- a/src/main/java/com/min/chalkakserver/controller/PhotoBoothController.java
+++ b/src/main/java/com/min/chalkakserver/controller/PhotoBoothController.java
@@ -165,6 +165,15 @@ public class PhotoBoothController {
         return ResponseEntity.ok(reports);
     }
 
+    @GetMapping("/reports/my/stats")
+    @Operation(summary = "내 제보 통계", description = "내가 제보한 사진관의 처리 상태별 통계를 조회합니다")
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<Map<String, Long>> getMyReportStats(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Map<String, Long> stats = photoBoothService.getMyReportStats(userDetails.getId());
+        return ResponseEntity.ok(stats);
+    }
+
     // ==================== 이미지 ====================
 
     @GetMapping("/{id}/images")

--- a/src/main/java/com/min/chalkakserver/controller/StatsController.java
+++ b/src/main/java/com/min/chalkakserver/controller/StatsController.java
@@ -1,0 +1,25 @@
+package com.min.chalkakserver.controller;
+
+import com.min.chalkakserver.service.StatsService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/stats")
+@RequiredArgsConstructor
+public class StatsController {
+
+    private final StatsService statsService;
+
+    @GetMapping("/summary")
+    @Operation(summary = "앱 공개 통계", description = "앱 정보 화면에 표시할 공개 요약 통계를 조회합니다")
+    public ResponseEntity<Map<String, Long>> getSummary() {
+        return ResponseEntity.ok(statsService.getSummary());
+    }
+}

--- a/src/main/java/com/min/chalkakserver/repository/PhotoBoothReportRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/PhotoBoothReportRepository.java
@@ -15,5 +15,9 @@ public interface PhotoBoothReportRepository extends JpaRepository<PhotoBoothRepo
     @Query("SELECT r FROM PhotoBoothReport r WHERE r.user = :user ORDER BY r.createdAt DESC")
     List<PhotoBoothReport> findByUser(@Param("user") User user);
 
+    long countByUser(User user);
+
+    long countByUserAndStatus(User user, PhotoBoothReport.ReportStatus status);
+
     void deleteAllByUser(User user);
 }

--- a/src/main/java/com/min/chalkakserver/service/AuthService.java
+++ b/src/main/java/com/min/chalkakserver/service/AuthService.java
@@ -220,10 +220,12 @@ public class AuthService {
 
         long reviewCount = reviewRepository.countByUser(user);
         long favoriteCount = favoriteRepository.countByUser(user);
+        long reportCount = photoBoothReportRepository.countByUser(user);
 
         return Map.of(
             "reviewCount", reviewCount,
-            "favoriteCount", favoriteCount
+            "favoriteCount", favoriteCount,
+            "reportCount", reportCount
         );
     }
 

--- a/src/main/java/com/min/chalkakserver/service/PhotoBoothService.java
+++ b/src/main/java/com/min/chalkakserver/service/PhotoBoothService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.min.chalkakserver.dto.PhotoBoothReportDto;
@@ -317,5 +318,21 @@ public class PhotoBoothService {
         return photoBoothReportRepository.findByUser(user).stream()
             .map(PhotoBoothReportResponseDto::from)
             .collect(Collectors.toList());
+    }
+
+    // 내 제보 통계 조회
+    @Transactional(readOnly = true)
+    public Map<String, Long> getMyReportStats(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException("User not found"));
+
+        return Map.of(
+            "totalCount", photoBoothReportRepository.countByUser(user),
+            "pendingCount", photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.PENDING),
+            "reviewingCount", photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.REVIEWING),
+            "approvedCount", photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.APPROVED),
+            "rejectedCount", photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.REJECTED),
+            "duplicateCount", photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.DUPLICATE)
+        );
     }
 }

--- a/src/main/java/com/min/chalkakserver/service/StatsService.java
+++ b/src/main/java/com/min/chalkakserver/service/StatsService.java
@@ -1,0 +1,28 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.repository.PhotoBoothRepository;
+import com.min.chalkakserver.repository.ReviewRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StatsService {
+
+    private final PhotoBoothRepository photoBoothRepository;
+    private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional(readOnly = true)
+    public Map<String, Long> getSummary() {
+        return Map.of(
+                "photoBoothCount", photoBoothRepository.count(),
+                "activeUserCount", userRepository.count(),
+                "reviewCount", reviewRepository.count()
+        );
+    }
+}

--- a/src/test/java/com/min/chalkakserver/controller/PhotoBoothControllerTest.java
+++ b/src/test/java/com/min/chalkakserver/controller/PhotoBoothControllerTest.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.min.chalkakserver.config.RateLimitConfig;
 import com.min.chalkakserver.config.WebMvcConfig;
 import com.min.chalkakserver.dto.PhotoBoothReportDto;
+import com.min.chalkakserver.entity.User;
 import com.min.chalkakserver.exception.PhotoBoothNotFoundException;
+import com.min.chalkakserver.security.CustomUserDetails;
 import com.min.chalkakserver.security.jwt.JwtAuthenticationFilter;
 import com.min.chalkakserver.service.EmailService;
+import com.min.chalkakserver.service.PhotoBoothImageService;
 import com.min.chalkakserver.service.PhotoBoothService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +19,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.reflect.Field;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -41,6 +49,9 @@ class PhotoBoothControllerTest {
 
     @MockBean
     private PhotoBoothService photoBoothService;
+
+    @MockBean
+    private PhotoBoothImageService photoBoothImageService;
 
     @MockBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -222,5 +233,46 @@ class PhotoBoothControllerTest {
                         .content(objectMapper.writeValueAsString(reportDto)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("제보가 접수되었습니다. 감사합니다!"));
+    }
+
+    @Test
+    void getMyReportStats_ShouldReturn200() throws Exception {
+        when(photoBoothService.getMyReportStats(1L)).thenReturn(Map.of(
+                "totalCount", 3L,
+                "pendingCount", 1L,
+                "reviewingCount", 1L,
+                "approvedCount", 1L,
+                "rejectedCount", 0L,
+                "duplicateCount", 0L
+        ));
+
+        PhotoBoothController controller = new PhotoBoothController(
+                photoBoothService,
+                photoBoothImageService,
+                emailService
+        );
+
+        ResponseEntity<Map<String, Long>> response = controller.getMyReportStats(customUserDetails(1L));
+
+        org.assertj.core.api.Assertions.assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        org.assertj.core.api.Assertions.assertThat(response.getBody())
+                .containsEntry("totalCount", 3L)
+                .containsEntry("pendingCount", 1L)
+                .containsEntry("reviewingCount", 1L)
+                .containsEntry("approvedCount", 1L);
+    }
+
+    private CustomUserDetails customUserDetails(Long id) throws Exception {
+        User testUser = User.builder()
+                .email("test@test.com")
+                .nickname("tester")
+                .provider(User.AuthProvider.EMAIL)
+                .providerId("test@test.com")
+                .role(User.Role.USER)
+                .build();
+        Field idField = User.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(testUser, id);
+        return new CustomUserDetails(testUser);
     }
 }

--- a/src/test/java/com/min/chalkakserver/controller/StatsControllerTest.java
+++ b/src/test/java/com/min/chalkakserver/controller/StatsControllerTest.java
@@ -1,0 +1,50 @@
+package com.min.chalkakserver.controller;
+
+import com.min.chalkakserver.service.StatsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Map;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StatsController 테스트")
+class StatsControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private StatsService statsService;
+
+    @BeforeEach
+    void setUp() {
+        StatsController statsController = new StatsController(statsService);
+        mockMvc = MockMvcBuilders.standaloneSetup(statsController).build();
+    }
+
+    @Test
+    @DisplayName("앱 통계 요약을 반환한다")
+    void getSummary_success() throws Exception {
+        given(statsService.getSummary()).willReturn(Map.of(
+                "photoBoothCount", 12L,
+                "activeUserCount", 34L,
+                "reviewCount", 56L
+        ));
+
+        mockMvc.perform(get("/api/stats/summary"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.photoBoothCount").value(12))
+            .andExpect(jsonPath("$.activeUserCount").value(34))
+            .andExpect(jsonPath("$.reviewCount").value(56));
+    }
+}

--- a/src/test/java/com/min/chalkakserver/service/PhotoBoothServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/PhotoBoothServiceTest.java
@@ -3,9 +3,14 @@ package com.min.chalkakserver.service;
 import com.min.chalkakserver.dto.PagedResponseDto;
 import com.min.chalkakserver.dto.PhotoBoothResponseDto;
 import com.min.chalkakserver.entity.PhotoBooth;
+import com.min.chalkakserver.entity.PhotoBoothReport;
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.repository.PhotoBoothImageRepository;
+import com.min.chalkakserver.repository.PhotoBoothReportRepository;
 import com.min.chalkakserver.exception.InvalidLocationException;
 import com.min.chalkakserver.exception.PhotoBoothNotFoundException;
 import com.min.chalkakserver.repository.PhotoBoothRepository;
+import com.min.chalkakserver.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -34,6 +39,15 @@ class PhotoBoothServiceTest {
 
     @Mock
     private PhotoBoothRepository photoBoothRepository;
+
+    @Mock
+    private PhotoBoothImageRepository photoBoothImageRepository;
+
+    @Mock
+    private PhotoBoothReportRepository photoBoothReportRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private PhotoBoothService photoBoothService;
@@ -132,6 +146,8 @@ class PhotoBoothServiceTest {
             // given
             given(photoBoothRepository.findById(1L))
                     .willReturn(Optional.of(testPhotoBooth));
+            given(photoBoothImageRepository.findByPhotoBoothIdOrderByDisplayOrder(1L))
+                    .willReturn(List.of());
 
             // when
             PhotoBoothResponseDto result = photoBoothService.getPhotoBoothById(1L);
@@ -152,6 +168,41 @@ class PhotoBoothServiceTest {
             // when & then
             assertThatThrownBy(() -> photoBoothService.getPhotoBoothById(999L))
                     .isInstanceOf(PhotoBoothNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("내 제보 통계 테스트")
+    class GetMyReportStatsTest {
+
+        @Test
+        @DisplayName("상태별 내 제보 통계를 조회한다")
+        void getMyReportStats_success() {
+            User user = User.builder()
+                    .email("test@test.com")
+                    .nickname("tester")
+                    .provider(User.AuthProvider.EMAIL)
+                    .providerId("test@test.com")
+                    .role(User.Role.USER)
+                    .build();
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(photoBoothReportRepository.countByUser(user)).willReturn(6L);
+            given(photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.PENDING)).willReturn(1L);
+            given(photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.REVIEWING)).willReturn(2L);
+            given(photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.APPROVED)).willReturn(3L);
+            given(photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.REJECTED)).willReturn(0L);
+            given(photoBoothReportRepository.countByUserAndStatus(user, PhotoBoothReport.ReportStatus.DUPLICATE)).willReturn(0L);
+
+            var result = photoBoothService.getMyReportStats(1L);
+
+            assertThat(result)
+                    .containsEntry("totalCount", 6L)
+                    .containsEntry("pendingCount", 1L)
+                    .containsEntry("reviewingCount", 2L)
+                    .containsEntry("approvedCount", 3L)
+                    .containsEntry("rejectedCount", 0L)
+                    .containsEntry("duplicateCount", 0L);
         }
     }
 

--- a/src/test/java/com/min/chalkakserver/service/StatsServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/StatsServiceTest.java
@@ -1,0 +1,48 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.repository.PhotoBoothRepository;
+import com.min.chalkakserver.repository.ReviewRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StatsService 테스트")
+class StatsServiceTest {
+
+    @Mock
+    private PhotoBoothRepository photoBoothRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @InjectMocks
+    private StatsService statsService;
+
+    @Test
+    @DisplayName("앱 통계 요약을 조회한다")
+    void getSummary_success() {
+        given(photoBoothRepository.count()).willReturn(12L);
+        given(userRepository.count()).willReturn(34L);
+        given(reviewRepository.count()).willReturn(56L);
+
+        Map<String, Long> result = statsService.getSummary();
+
+        assertThat(result)
+                .containsEntry("photoBoothCount", 12L)
+                .containsEntry("activeUserCount", 34L)
+                .containsEntry("reviewCount", 56L);
+    }
+}


### PR DESCRIPTION
## Summary
- Add public `/api/stats/summary` endpoint for app-info stats.
- Add report stats support via `/api/photo-booths/reports/my/stats`.
- Include `reportCount` in `/api/auth/me/stats` for my-page UI.
- Add focused controller/service tests for stats and report count behavior.

## Verification
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew test --tests 'com.min.chalkakserver.service.StatsServiceTest' --tests 'com.min.chalkakserver.controller.StatsControllerTest' --tests 'com.min.chalkakserver.service.PhotoBoothServiceTest' --tests 'com.min.chalkakserver.controller.PhotoBoothControllerTest' --tests 'com.min.chalkakserver.service.AuthServiceTest'`
- `git diff --check`

## Notes
- Full backend suite still has pre-existing unrelated ApplicationContext/Admin/Congestion/Cache failures.
