### PR TITLE
한정판 프레임 콜라보 · 재고 제보 · 포토북/도감 · 후보 큐

### DIFF
--- a/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
+++ b/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
@@ -59,6 +59,8 @@ public class SecurityConfig {
                 // 포토부스 조회 API는 인증 없이 허용 (GET만)
                 .requestMatchers(HttpMethod.GET, "/api/photo-booths/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/congestion/**").permitAll()
+                // 프레임 콜라보 조회는 인증 없이 허용 (GET만)
+                .requestMatchers(HttpMethod.GET, "/api/frame-collabs/**").permitAll()
                 // 최근 리뷰 피드는 인증 없이 허용
                 .requestMatchers(HttpMethod.GET, "/api/reviews/recent").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/stats/**").permitAll()

--- a/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
+++ b/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
@@ -61,6 +61,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/congestion/**").permitAll()
                 // 프레임 콜라보 조회는 인증 없이 허용 (GET만)
                 .requestMatchers(HttpMethod.GET, "/api/frame-collabs/**").permitAll()
+                // 프레임 재고 조회는 인증 없이 허용 (GET만)
+                .requestMatchers(HttpMethod.GET, "/api/frame-availability/**").permitAll()
                 // 최근 리뷰 피드는 인증 없이 허용
                 .requestMatchers(HttpMethod.GET, "/api/reviews/recent").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/stats/**").permitAll()

--- a/src/main/java/com/min/chalkakserver/controller/AdminController.java
+++ b/src/main/java/com/min/chalkakserver/controller/AdminController.java
@@ -5,9 +5,13 @@ import com.min.chalkakserver.dto.PhotoBoothRequestDto;
 import com.min.chalkakserver.dto.PhotoBoothResponseDto;
 import com.min.chalkakserver.dto.admin.AdminStatsDto;
 import com.min.chalkakserver.dto.admin.UserListResponseDto;
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateApproveRequestDto;
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateRequestDto;
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateResponseDto;
 import com.min.chalkakserver.dto.framecollab.FrameCollabDetailResponseDto;
 import com.min.chalkakserver.dto.framecollab.FrameCollabRequestDto;
 import com.min.chalkakserver.service.AdminService;
+import com.min.chalkakserver.service.CollabCandidateService;
 import com.min.chalkakserver.service.FrameCollabService;
 import com.min.chalkakserver.service.TagService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +38,7 @@ public class AdminController {
     private final AdminService adminService;
     private final TagService tagService;
     private final FrameCollabService frameCollabService;
+    private final CollabCandidateService collabCandidateService;
 
     // ==================== 대시보드 ====================
 
@@ -152,6 +157,38 @@ public class AdminController {
             @PathVariable Long id,
             @RequestBody List<Long> photoBoothIds) {
         return ResponseEntity.ok(frameCollabService.setPhotoBooths(id, photoBoothIds));
+    }
+
+    // ==================== 콜라보 후보 큐 ====================
+
+    @Operation(summary = "콜라보 후보 등록", description = "공지 텍스트를 붙여넣으면 파싱된 초안 후보를 생성합니다.")
+    @PostMapping("/collab-candidates")
+    public ResponseEntity<CollabCandidateResponseDto> createCollabCandidate(
+            @Valid @RequestBody CollabCandidateRequestDto request) {
+        return ResponseEntity.ok(collabCandidateService.createCandidate(request));
+    }
+
+    @Operation(summary = "콜라보 후보 목록", description = "상태별 후보 목록 조회 (pending/approved/rejected/all)")
+    @GetMapping("/collab-candidates")
+    public ResponseEntity<PagedResponseDto<CollabCandidateResponseDto>> getCollabCandidates(
+            @RequestParam(defaultValue = "pending") String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(collabCandidateService.getCandidates(status, page, size));
+    }
+
+    @Operation(summary = "콜라보 후보 승인", description = "후보를 승인해 프레임 콜라보로 등록합니다. body로 초안 필드 덮어쓰기 가능.")
+    @PostMapping("/collab-candidates/{id}/approve")
+    public ResponseEntity<FrameCollabDetailResponseDto> approveCollabCandidate(
+            @PathVariable Long id,
+            @RequestBody(required = false) @Valid CollabCandidateApproveRequestDto request) {
+        return ResponseEntity.ok(collabCandidateService.approveCandidate(id, request));
+    }
+
+    @Operation(summary = "콜라보 후보 거절", description = "후보를 거절 처리합니다.")
+    @PostMapping("/collab-candidates/{id}/reject")
+    public ResponseEntity<CollabCandidateResponseDto> rejectCollabCandidate(@PathVariable Long id) {
+        return ResponseEntity.ok(collabCandidateService.rejectCandidate(id));
     }
 
     // ==================== 태그 관리 ====================

--- a/src/main/java/com/min/chalkakserver/controller/AdminController.java
+++ b/src/main/java/com/min/chalkakserver/controller/AdminController.java
@@ -5,7 +5,10 @@ import com.min.chalkakserver.dto.PhotoBoothRequestDto;
 import com.min.chalkakserver.dto.PhotoBoothResponseDto;
 import com.min.chalkakserver.dto.admin.AdminStatsDto;
 import com.min.chalkakserver.dto.admin.UserListResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabDetailResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabRequestDto;
 import com.min.chalkakserver.service.AdminService;
+import com.min.chalkakserver.service.FrameCollabService;
 import com.min.chalkakserver.service.TagService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -30,6 +33,7 @@ public class AdminController {
 
     private final AdminService adminService;
     private final TagService tagService;
+    private final FrameCollabService frameCollabService;
 
     // ==================== 대시보드 ====================
 
@@ -116,6 +120,38 @@ public class AdminController {
     public ResponseEntity<Map<String, String>> deletePost(@PathVariable Long postId) {
         adminService.deletePost(postId);
         return ResponseEntity.ok(Map.of("message", "포스트가 삭제되었습니다."));
+    }
+
+    // ==================== 프레임 콜라보 관리 ====================
+
+    @Operation(summary = "프레임 콜라보 생성", description = "새 프레임 콜라보 등록 (입고 매장 포함 가능)")
+    @PostMapping("/frame-collabs")
+    public ResponseEntity<FrameCollabDetailResponseDto> createFrameCollab(
+            @Valid @RequestBody FrameCollabRequestDto request) {
+        return ResponseEntity.ok(frameCollabService.createCollab(request));
+    }
+
+    @Operation(summary = "프레임 콜라보 수정", description = "프레임 콜라보 정보 수정")
+    @PutMapping("/frame-collabs/{id}")
+    public ResponseEntity<FrameCollabDetailResponseDto> updateFrameCollab(
+            @PathVariable Long id,
+            @Valid @RequestBody FrameCollabRequestDto request) {
+        return ResponseEntity.ok(frameCollabService.updateCollab(id, request));
+    }
+
+    @Operation(summary = "프레임 콜라보 삭제", description = "프레임 콜라보 삭제")
+    @DeleteMapping("/frame-collabs/{id}")
+    public ResponseEntity<Map<String, String>> deleteFrameCollab(@PathVariable Long id) {
+        frameCollabService.deleteCollab(id);
+        return ResponseEntity.ok(Map.of("message", "프레임 콜라보가 삭제되었습니다."));
+    }
+
+    @Operation(summary = "콜라보 입고 매장 설정", description = "콜라보에 입고 매장 일괄 설정")
+    @PutMapping("/frame-collabs/{id}/booths")
+    public ResponseEntity<FrameCollabDetailResponseDto> setFrameCollabBooths(
+            @PathVariable Long id,
+            @RequestBody List<Long> photoBoothIds) {
+        return ResponseEntity.ok(frameCollabService.setPhotoBooths(id, photoBoothIds));
     }
 
     // ==================== 태그 관리 ====================

--- a/src/main/java/com/min/chalkakserver/controller/FrameAvailabilityController.java
+++ b/src/main/java/com/min/chalkakserver/controller/FrameAvailabilityController.java
@@ -1,0 +1,56 @@
+package com.min.chalkakserver.controller;
+
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityReportRequestDto;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityReportResponseDto;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityResponseDto;
+import com.min.chalkakserver.security.CustomUserDetails;
+import com.min.chalkakserver.service.FrameAvailabilityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "FrameAvailability", description = "프레임 재고 제보 API")
+@RestController
+@RequestMapping("/api/frame-availability")
+@RequiredArgsConstructor
+public class FrameAvailabilityController {
+
+    private final FrameAvailabilityService frameAvailabilityService;
+
+    @Operation(summary = "매장별 프레임 재고 조회", description = "특정 콜라보의 특정 매장 재고 상태를 최근 제보 기반으로 집계해 반환합니다.")
+    @GetMapping("/collab/{frameCollabId}/booth/{photoBoothId}")
+    public ResponseEntity<FrameAvailabilityResponseDto> getAvailability(
+            @PathVariable Long frameCollabId,
+            @PathVariable Long photoBoothId
+    ) {
+        return ResponseEntity.ok(frameAvailabilityService.getAvailability(frameCollabId, photoBoothId));
+    }
+
+    @Operation(summary = "콜라보 전체 매장 재고 조회", description = "콜라보의 모든 입고 매장 재고 상태를 한번에 조회합니다.")
+    @GetMapping("/collab/{frameCollabId}")
+    public ResponseEntity<List<FrameAvailabilityResponseDto>> getCollabAvailability(
+            @PathVariable Long frameCollabId
+    ) {
+        return ResponseEntity.ok(frameAvailabilityService.getCollabAvailability(frameCollabId));
+    }
+
+    @Operation(summary = "프레임 재고 제보", description = "로그인 사용자가 매장의 프레임 재고 상태(있음/품절)를 제보합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/collab/{frameCollabId}/booth/{photoBoothId}")
+    public ResponseEntity<FrameAvailabilityReportResponseDto> submitReport(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long frameCollabId,
+            @PathVariable Long photoBoothId,
+            @Valid @RequestBody FrameAvailabilityReportRequestDto request
+    ) {
+        return ResponseEntity.ok(frameAvailabilityService.submitReport(
+                userDetails.getId(), frameCollabId, photoBoothId, request));
+    }
+}

--- a/src/main/java/com/min/chalkakserver/controller/FrameCollabController.java
+++ b/src/main/java/com/min/chalkakserver/controller/FrameCollabController.java
@@ -1,0 +1,53 @@
+package com.min.chalkakserver.controller;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabDetailResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabResponseDto;
+import com.min.chalkakserver.service.FrameCollabService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "FrameCollab", description = "한정판 프레임 콜라보 API")
+@RestController
+@RequestMapping("/api/frame-collabs")
+@RequiredArgsConstructor
+@Validated
+public class FrameCollabController {
+
+    private final FrameCollabService frameCollabService;
+
+    @Operation(summary = "콜라보 피드 조회", description = "상태별 프레임 콜라보 목록을 조회합니다. (active: 진행중, upcoming: 예정, ended: 종료)")
+    @GetMapping
+    public ResponseEntity<PagedResponseDto<FrameCollabResponseDto>> getCollabs(
+            @RequestParam(defaultValue = "active")
+            @Pattern(regexp = "active|upcoming|ended", message = "status는 active, upcoming, ended 중 하나여야 합니다.")
+            String status,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        return ResponseEntity.ok(frameCollabService.getCollabs(status, page, size));
+    }
+
+    @Operation(summary = "콜라보 상세 조회", description = "콜라보 상세 정보와 입고 매장 목록을 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<FrameCollabDetailResponseDto> getCollab(@PathVariable Long id) {
+        return ResponseEntity.ok(frameCollabService.getCollab(id));
+    }
+
+    @Operation(summary = "매장별 콜라보 조회", description = "특정 사진관에서 진행 중이거나 예정된 콜라보 목록을 조회합니다.")
+    @GetMapping("/photo-booth/{photoBoothId}")
+    public ResponseEntity<List<FrameCollabResponseDto>> getCollabsByPhotoBooth(
+            @PathVariable Long photoBoothId
+    ) {
+        return ResponseEntity.ok(frameCollabService.getCollabsByPhotoBooth(photoBoothId));
+    }
+}

--- a/src/main/java/com/min/chalkakserver/controller/PhotobookController.java
+++ b/src/main/java/com/min/chalkakserver/controller/PhotobookController.java
@@ -1,0 +1,81 @@
+package com.min.chalkakserver.controller;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.photobook.PhotobookCollectionResponseDto;
+import com.min.chalkakserver.dto.photobook.PhotobookEntryRequestDto;
+import com.min.chalkakserver.dto.photobook.PhotobookEntryResponseDto;
+import com.min.chalkakserver.security.CustomUserDetails;
+import com.min.chalkakserver.service.PhotobookService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Tag(name = "Photobook", description = "디지털 포토북/도감 API")
+@RestController
+@RequestMapping("/api/photobook")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+@Validated
+public class PhotobookController {
+
+    private final PhotobookService photobookService;
+
+    @Operation(summary = "포토북 사진 등록", description = "업로드한 이미지 URL로 포토북에 사진을 등록합니다. 콜라보/매장 태깅 가능.")
+    @PostMapping
+    public ResponseEntity<PhotobookEntryResponseDto> createEntry(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PhotobookEntryRequestDto request
+    ) {
+        return ResponseEntity.ok(photobookService.createEntry(userDetails.getId(), request));
+    }
+
+    @Operation(summary = "내 포토북 조회", description = "내가 등록한 사진을 최신순으로 조회합니다.")
+    @GetMapping("/my")
+    public ResponseEntity<PagedResponseDto<PhotobookEntryResponseDto>> getMyEntries(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        return ResponseEntity.ok(photobookService.getMyEntries(userDetails.getId(), page, size));
+    }
+
+    @Operation(summary = "콜라보별 내 포토북 조회", description = "특정 콜라보로 태깅된 내 사진을 조회합니다.")
+    @GetMapping("/my/collab/{frameCollabId}")
+    public ResponseEntity<PagedResponseDto<PhotobookEntryResponseDto>> getMyEntriesByCollab(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long frameCollabId,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size
+    ) {
+        return ResponseEntity.ok(photobookService.getMyEntriesByCollab(
+                userDetails.getId(), frameCollabId, page, size));
+    }
+
+    @Operation(summary = "내 도감 조회", description = "콜라보별 수집 현황(사진 수, 수집 여부)을 반환합니다.")
+    @GetMapping("/my/collection")
+    public ResponseEntity<PhotobookCollectionResponseDto> getMyCollection(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(photobookService.getMyCollection(userDetails.getId()));
+    }
+
+    @Operation(summary = "포토북 사진 삭제", description = "내가 등록한 사진을 삭제합니다.")
+    @DeleteMapping("/{entryId}")
+    public ResponseEntity<Map<String, String>> deleteEntry(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long entryId
+    ) {
+        photobookService.deleteEntry(userDetails.getId(), entryId);
+        return ResponseEntity.ok(Map.of("message", "포토북 사진이 삭제되었습니다."));
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/collabcandidate/CollabCandidateApproveRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/collabcandidate/CollabCandidateApproveRequestDto.java
@@ -1,0 +1,41 @@
+package com.min.chalkakserver.dto.collabcandidate;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 후보 승인 시 파싱된 초안을 덮어쓸 수 있는 선택 필드들.
+ * null인 필드는 후보의 파싱 값을 그대로 사용한다.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CollabCandidateApproveRequestDto {
+
+    @Size(max = 150, message = "콜라보 제목은 150자 이하여야 합니다.")
+    private String title;
+
+    @Size(max = 50, message = "브랜드명은 50자 이하여야 합니다.")
+    private String brand;
+
+    @Size(max = 100, message = "아티스트명은 100자 이하여야 합니다.")
+    private String artistName;
+
+    private String description;
+
+    @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다.")
+    private String imageUrl;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private List<Long> photoBoothIds;
+}

--- a/src/main/java/com/min/chalkakserver/dto/collabcandidate/CollabCandidateRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/collabcandidate/CollabCandidateRequestDto.java
@@ -1,0 +1,21 @@
+package com.min.chalkakserver.dto.collabcandidate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CollabCandidateRequestDto {
+
+    @Size(max = 500, message = "출처 URL은 500자 이하여야 합니다.")
+    private String sourceUrl;
+
+    @NotBlank(message = "공지 텍스트는 필수입니다.")
+    private String rawText;
+}

--- a/src/main/java/com/min/chalkakserver/dto/collabcandidate/CollabCandidateResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/collabcandidate/CollabCandidateResponseDto.java
@@ -1,0 +1,45 @@
+package com.min.chalkakserver.dto.collabcandidate;
+
+import com.min.chalkakserver.entity.CollabCandidate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CollabCandidateResponseDto {
+
+    private Long id;
+    private String sourceUrl;
+    private String rawText;
+    private String title;
+    private String brand;
+    private String artistName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private CollabCandidate.CandidateStatus status;
+    private Long createdFrameCollabId;
+    private LocalDateTime createdAt;
+
+    public static CollabCandidateResponseDto from(CollabCandidate candidate) {
+        return CollabCandidateResponseDto.builder()
+                .id(candidate.getId())
+                .sourceUrl(candidate.getSourceUrl())
+                .rawText(candidate.getRawText())
+                .title(candidate.getTitle())
+                .brand(candidate.getBrand())
+                .artistName(candidate.getArtistName())
+                .startDate(candidate.getStartDate())
+                .endDate(candidate.getEndDate())
+                .status(candidate.getStatus())
+                .createdFrameCollabId(candidate.getCreatedFrameCollabId())
+                .createdAt(candidate.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/frameavailability/FrameAvailabilityReportRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/frameavailability/FrameAvailabilityReportRequestDto.java
@@ -1,0 +1,18 @@
+package com.min.chalkakserver.dto.frameavailability;
+
+import com.min.chalkakserver.entity.FrameAvailabilityReport;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FrameAvailabilityReportRequestDto {
+
+    @NotNull(message = "재고 상태는 필수입니다.")
+    private FrameAvailabilityReport.AvailabilityStatus availabilityStatus;
+}

--- a/src/main/java/com/min/chalkakserver/dto/frameavailability/FrameAvailabilityReportResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/frameavailability/FrameAvailabilityReportResponseDto.java
@@ -1,0 +1,20 @@
+package com.min.chalkakserver.dto.frameavailability;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FrameAvailabilityReportResponseDto {
+
+    private Long frameCollabId;
+    private Long photoBoothId;
+    private String message;
+    private LocalDateTime submittedAt;
+}

--- a/src/main/java/com/min/chalkakserver/dto/frameavailability/FrameAvailabilityResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/frameavailability/FrameAvailabilityResponseDto.java
@@ -1,0 +1,35 @@
+package com.min.chalkakserver.dto.frameavailability;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FrameAvailabilityResponseDto {
+
+    private Long frameCollabId;
+    private Long photoBoothId;
+    private ResultStatus status;
+    private ConfidenceLevel confidenceLevel;
+    private int sampleSize;
+    private LocalDateTime lastUpdatedAt;
+    private String message;
+
+    public enum ResultStatus {
+        AVAILABLE,
+        SOLD_OUT,
+        UNKNOWN
+    }
+
+    public enum ConfidenceLevel {
+        LOW,
+        MEDIUM,
+        HIGH
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/framecollab/FrameCollabDetailResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/framecollab/FrameCollabDetailResponseDto.java
@@ -1,0 +1,54 @@
+package com.min.chalkakserver.dto.framecollab;
+
+import com.min.chalkakserver.dto.PhotoBoothResponseDto;
+import com.min.chalkakserver.entity.FrameCollab;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FrameCollabDetailResponseDto {
+
+    private Long id;
+    private String title;
+    private String brand;
+    private String artistName;
+    private String description;
+    private String imageUrl;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private FrameCollab.CollabStatus status;
+    private List<PhotoBoothResponseDto> photoBooths;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static FrameCollabDetailResponseDto from(FrameCollab frameCollab, LocalDate today) {
+        List<PhotoBoothResponseDto> booths = frameCollab.getPhotoBooths().stream()
+                .sorted(Comparator.comparing(pb -> pb.getId()))
+                .map(PhotoBoothResponseDto::from)
+                .toList();
+        return FrameCollabDetailResponseDto.builder()
+                .id(frameCollab.getId())
+                .title(frameCollab.getTitle())
+                .brand(frameCollab.getBrand())
+                .artistName(frameCollab.getArtistName())
+                .description(frameCollab.getDescription())
+                .imageUrl(frameCollab.getImageUrl())
+                .startDate(frameCollab.getStartDate())
+                .endDate(frameCollab.getEndDate())
+                .status(frameCollab.getStatus(today))
+                .photoBooths(booths)
+                .createdAt(frameCollab.getCreatedAt())
+                .updatedAt(frameCollab.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/framecollab/FrameCollabRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/framecollab/FrameCollabRequestDto.java
@@ -1,0 +1,53 @@
+package com.min.chalkakserver.dto.framecollab;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FrameCollabRequestDto {
+
+    @NotBlank(message = "콜라보 제목은 필수입니다.")
+    @Size(max = 150, message = "콜라보 제목은 150자 이하여야 합니다.")
+    private String title;
+
+    @Size(max = 50, message = "브랜드명은 50자 이하여야 합니다.")
+    private String brand;
+
+    @Size(max = 100, message = "아티스트명은 100자 이하여야 합니다.")
+    private String artistName;
+
+    private String description;
+
+    @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다.")
+    private String imageUrl;
+
+    @NotNull(message = "시작일은 필수입니다.")
+    private LocalDate startDate;
+
+    @NotNull(message = "종료일은 필수입니다.")
+    private LocalDate endDate;
+
+    private List<Long> photoBoothIds;
+
+    @JsonIgnore
+    @AssertTrue(message = "종료일은 시작일보다 빠를 수 없습니다.")
+    public boolean isValidPeriod() {
+        if (startDate == null || endDate == null) {
+            return true;
+        }
+        return !endDate.isBefore(startDate);
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/framecollab/FrameCollabResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/framecollab/FrameCollabResponseDto.java
@@ -1,0 +1,47 @@
+package com.min.chalkakserver.dto.framecollab;
+
+import com.min.chalkakserver.entity.FrameCollab;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FrameCollabResponseDto {
+
+    private Long id;
+    private String title;
+    private String brand;
+    private String artistName;
+    private String description;
+    private String imageUrl;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private FrameCollab.CollabStatus status;
+    private int photoBoothCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static FrameCollabResponseDto from(FrameCollab frameCollab, LocalDate today) {
+        return FrameCollabResponseDto.builder()
+                .id(frameCollab.getId())
+                .title(frameCollab.getTitle())
+                .brand(frameCollab.getBrand())
+                .artistName(frameCollab.getArtistName())
+                .description(frameCollab.getDescription())
+                .imageUrl(frameCollab.getImageUrl())
+                .startDate(frameCollab.getStartDate())
+                .endDate(frameCollab.getEndDate())
+                .status(frameCollab.getStatus(today))
+                .photoBoothCount(frameCollab.getPhotoBooths().size())
+                .createdAt(frameCollab.getCreatedAt())
+                .updatedAt(frameCollab.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/photobook/PhotobookCollectionResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/photobook/PhotobookCollectionResponseDto.java
@@ -1,0 +1,55 @@
+package com.min.chalkakserver.dto.photobook;
+
+import com.min.chalkakserver.entity.FrameCollab;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PhotobookCollectionResponseDto {
+
+    private int totalCollabs;
+    private int collectedCollabs;
+    private long totalPhotos;
+    private List<CollectionItemDto> items;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CollectionItemDto {
+
+        private Long frameCollabId;
+        private String title;
+        private String brand;
+        private String artistName;
+        private String imageUrl;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private FrameCollab.CollabStatus status;
+        private long photoCount;
+        private boolean collected;
+
+        public static CollectionItemDto from(FrameCollab collab, LocalDate today, long photoCount) {
+            return CollectionItemDto.builder()
+                    .frameCollabId(collab.getId())
+                    .title(collab.getTitle())
+                    .brand(collab.getBrand())
+                    .artistName(collab.getArtistName())
+                    .imageUrl(collab.getImageUrl())
+                    .startDate(collab.getStartDate())
+                    .endDate(collab.getEndDate())
+                    .status(collab.getStatus(today))
+                    .photoCount(photoCount)
+                    .collected(photoCount > 0)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/photobook/PhotobookEntryRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/photobook/PhotobookEntryRequestDto.java
@@ -1,0 +1,30 @@
+package com.min.chalkakserver.dto.photobook;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PhotobookEntryRequestDto {
+
+    @NotBlank(message = "이미지 URL은 필수입니다.")
+    @Size(max = 500, message = "이미지 URL은 500자 이하여야 합니다.")
+    private String imageUrl;
+
+    private Long frameCollabId;
+
+    private Long photoBoothId;
+
+    private LocalDate takenAt;
+
+    @Size(max = 1000, message = "메모는 1000자 이하여야 합니다.")
+    private String memo;
+}

--- a/src/main/java/com/min/chalkakserver/dto/photobook/PhotobookEntryResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/photobook/PhotobookEntryResponseDto.java
@@ -1,0 +1,43 @@
+package com.min.chalkakserver.dto.photobook;
+
+import com.min.chalkakserver.entity.PhotobookEntry;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PhotobookEntryResponseDto {
+
+    private Long id;
+    private String imageUrl;
+    private Long frameCollabId;
+    private String frameCollabTitle;
+    private String frameCollabArtistName;
+    private Long photoBoothId;
+    private String photoBoothName;
+    private LocalDate takenAt;
+    private String memo;
+    private LocalDateTime createdAt;
+
+    public static PhotobookEntryResponseDto from(PhotobookEntry entry) {
+        return PhotobookEntryResponseDto.builder()
+                .id(entry.getId())
+                .imageUrl(entry.getImageUrl())
+                .frameCollabId(entry.getFrameCollab() != null ? entry.getFrameCollab().getId() : null)
+                .frameCollabTitle(entry.getFrameCollab() != null ? entry.getFrameCollab().getTitle() : null)
+                .frameCollabArtistName(entry.getFrameCollab() != null ? entry.getFrameCollab().getArtistName() : null)
+                .photoBoothId(entry.getPhotoBooth() != null ? entry.getPhotoBooth().getId() : null)
+                .photoBoothName(entry.getPhotoBooth() != null ? entry.getPhotoBooth().getName() : null)
+                .takenAt(entry.getTakenAt())
+                .memo(entry.getMemo())
+                .createdAt(entry.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/entity/CollabCandidate.java
+++ b/src/main/java/com/min/chalkakserver/entity/CollabCandidate.java
@@ -1,0 +1,97 @@
+package com.min.chalkakserver.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "collab_candidates",
+    indexes = {
+        @Index(name = "idx_candidate_status_created_at", columnList = "status,created_at")
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CollabCandidate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "source_url", length = 500)
+    private String sourceUrl;
+
+    @Column(name = "raw_text", columnDefinition = "TEXT", nullable = false)
+    private String rawText;
+
+    @Column(length = 150)
+    private String title;
+
+    @Column(length = 50)
+    private String brand;
+
+    @Column(name = "artist_name", length = 100)
+    private String artistName;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CandidateStatus status;
+
+    @Column(name = "created_frame_collab_id")
+    private Long createdFrameCollabId;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public CollabCandidate(String sourceUrl, String rawText, String title, String brand,
+                           String artistName, LocalDate startDate, LocalDate endDate) {
+        this.sourceUrl = sourceUrl;
+        this.rawText = rawText;
+        this.title = title;
+        this.brand = brand;
+        this.artistName = artistName;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = CandidateStatus.PENDING;
+    }
+
+    public void approve(Long frameCollabId) {
+        this.status = CandidateStatus.APPROVED;
+        this.createdFrameCollabId = frameCollabId;
+    }
+
+    public void reject() {
+        this.status = CandidateStatus.REJECTED;
+    }
+
+    public enum CandidateStatus {
+        PENDING,
+        APPROVED,
+        REJECTED
+    }
+}

--- a/src/main/java/com/min/chalkakserver/entity/FrameAvailabilityReport.java
+++ b/src/main/java/com/min/chalkakserver/entity/FrameAvailabilityReport.java
@@ -1,0 +1,74 @@
+package com.min.chalkakserver.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "frame_availability_reports",
+    indexes = {
+        @Index(name = "idx_availability_collab_booth_created_at",
+               columnList = "frame_collab_id,photo_booth_id,created_at"),
+        @Index(name = "idx_availability_user_collab_booth_created_at",
+               columnList = "user_id,frame_collab_id,photo_booth_id,created_at")
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FrameAvailabilityReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "frame_collab_id", nullable = false)
+    private FrameCollab frameCollab;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_booth_id", nullable = false)
+    private PhotoBooth photoBooth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "availability_status", nullable = false, length = 20)
+    private AvailabilityStatus availabilityStatus;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public FrameAvailabilityReport(User user, FrameCollab frameCollab, PhotoBooth photoBooth,
+                                   AvailabilityStatus availabilityStatus) {
+        this.user = user;
+        this.frameCollab = frameCollab;
+        this.photoBooth = photoBooth;
+        this.availabilityStatus = availabilityStatus;
+    }
+
+    public enum AvailabilityStatus {
+        AVAILABLE(1),
+        SOLD_OUT(0);
+
+        private final int score;
+
+        AvailabilityStatus(int score) {
+            this.score = score;
+        }
+
+        public int getScore() {
+            return score;
+        }
+    }
+}

--- a/src/main/java/com/min/chalkakserver/entity/FrameCollab.java
+++ b/src/main/java/com/min/chalkakserver/entity/FrameCollab.java
@@ -1,0 +1,118 @@
+package com.min.chalkakserver.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "frame_collabs",
+    indexes = {
+        @Index(name = "idx_collab_period", columnList = "start_date,end_date"),
+        @Index(name = "idx_collab_brand", columnList = "brand"),
+        @Index(name = "idx_collab_artist", columnList = "artist_name")
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FrameCollab {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 150)
+    private String title;
+
+    @Column(length = 50)
+    private String brand;
+
+    @Column(name = "artist_name", length = 100)
+    private String artistName;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "frame_collab_booths",
+        joinColumns = @JoinColumn(name = "frame_collab_id"),
+        inverseJoinColumns = @JoinColumn(name = "photo_booth_id")
+    )
+    private Set<PhotoBooth> photoBooths = new HashSet<>();
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public FrameCollab(String title, String brand, String artistName, String description,
+                       String imageUrl, LocalDate startDate, LocalDate endDate) {
+        this.title = title;
+        this.brand = brand;
+        this.artistName = artistName;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public void update(String title, String brand, String artistName, String description,
+                       String imageUrl, LocalDate startDate, LocalDate endDate) {
+        this.title = title;
+        this.brand = brand;
+        this.artistName = artistName;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public void updatePhotoBooths(Set<PhotoBooth> newBooths) {
+        this.photoBooths.clear();
+        this.photoBooths.addAll(newBooths);
+    }
+
+    public CollabStatus getStatus(LocalDate today) {
+        if (today.isBefore(startDate)) {
+            return CollabStatus.UPCOMING;
+        }
+        if (today.isAfter(endDate)) {
+            return CollabStatus.ENDED;
+        }
+        return CollabStatus.ACTIVE;
+    }
+
+    public enum CollabStatus {
+        UPCOMING,
+        ACTIVE,
+        ENDED
+    }
+}

--- a/src/main/java/com/min/chalkakserver/entity/FrameCollab.java
+++ b/src/main/java/com/min/chalkakserver/entity/FrameCollab.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -53,7 +54,9 @@ public class FrameCollab {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    // 피드 목록에서 콜라보별 매장 수(getPhotoBooths().size())를 읽을 때 N+1을 줄이기 위해 배치 로딩
     @ManyToMany(fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     @JoinTable(
         name = "frame_collab_booths",
         joinColumns = @JoinColumn(name = "frame_collab_id"),

--- a/src/main/java/com/min/chalkakserver/entity/PhotobookEntry.java
+++ b/src/main/java/com/min/chalkakserver/entity/PhotobookEntry.java
@@ -1,0 +1,74 @@
+package com.min.chalkakserver.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "photobook_entries",
+    indexes = {
+        @Index(name = "idx_photobook_user_created_at", columnList = "user_id,created_at"),
+        @Index(name = "idx_photobook_user_collab", columnList = "user_id,frame_collab_id")
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhotobookEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "frame_collab_id")
+    private FrameCollab frameCollab;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photo_booth_id")
+    private PhotoBooth photoBooth;
+
+    @Column(name = "image_url", length = 500, nullable = false)
+    private String imageUrl;
+
+    @Column(name = "taken_at")
+    private LocalDate takenAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String memo;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public PhotobookEntry(User user, FrameCollab frameCollab, PhotoBooth photoBooth,
+                          String imageUrl, LocalDate takenAt, String memo) {
+        this.user = user;
+        this.frameCollab = frameCollab;
+        this.photoBooth = photoBooth;
+        this.imageUrl = imageUrl;
+        this.takenAt = takenAt;
+        this.memo = memo;
+    }
+}

--- a/src/main/java/com/min/chalkakserver/exception/CollabCandidateNotFoundException.java
+++ b/src/main/java/com/min/chalkakserver/exception/CollabCandidateNotFoundException.java
@@ -1,0 +1,14 @@
+package com.min.chalkakserver.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CollabCandidateNotFoundException extends RuntimeException {
+
+    private final Long candidateId;
+
+    public CollabCandidateNotFoundException(Long candidateId) {
+        super(String.format("콜라보 후보를 찾을 수 없습니다. ID: %d", candidateId));
+        this.candidateId = candidateId;
+    }
+}

--- a/src/main/java/com/min/chalkakserver/exception/DuplicateAvailabilityReportException.java
+++ b/src/main/java/com/min/chalkakserver/exception/DuplicateAvailabilityReportException.java
@@ -1,0 +1,15 @@
+package com.min.chalkakserver.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateAvailabilityReportException extends RuntimeException {
+    private final Long frameCollabId;
+    private final Long photoBoothId;
+
+    public DuplicateAvailabilityReportException(Long frameCollabId, Long photoBoothId) {
+        super("이미 최근 1시간 내에 이 매장의 프레임 재고를 제보했습니다.");
+        this.frameCollabId = frameCollabId;
+        this.photoBoothId = photoBoothId;
+    }
+}

--- a/src/main/java/com/min/chalkakserver/exception/FrameCollabNotFoundException.java
+++ b/src/main/java/com/min/chalkakserver/exception/FrameCollabNotFoundException.java
@@ -1,0 +1,18 @@
+package com.min.chalkakserver.exception;
+
+/**
+ * 프레임 콜라보를 찾을 수 없을 때 발생하는 예외
+ */
+public class FrameCollabNotFoundException extends RuntimeException {
+
+    private final Long frameCollabId;
+
+    public FrameCollabNotFoundException(Long frameCollabId) {
+        super(String.format("프레임 콜라보를 찾을 수 없습니다. ID: %d", frameCollabId));
+        this.frameCollabId = frameCollabId;
+    }
+
+    public Long getFrameCollabId() {
+        return frameCollabId;
+    }
+}

--- a/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
@@ -268,6 +268,27 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
     }
 
+    @ExceptionHandler(DuplicateAvailabilityReportException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateAvailabilityReportException(
+            DuplicateAvailabilityReportException ex, HttpServletRequest request) {
+
+        log.error("Duplicate availability report: {}", ex.getMessage());
+
+        Map<String, Object> details = new HashMap<>();
+        details.put("frameCollabId", ex.getFrameCollabId());
+        details.put("photoBoothId", ex.getPhotoBoothId());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.CONFLICT.value(),
+            "Conflict",
+            ex.getMessage(),
+            request.getRequestURI(),
+            details
+        );
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+    }
+
     @ExceptionHandler(DuplicateCongestionReportException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateCongestionReportException(
             DuplicateCongestionReportException ex, HttpServletRequest request) {

--- a/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
@@ -51,6 +51,31 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 포토북 사진을 찾을 수 없는 경우
+     */
+    @ExceptionHandler(PhotobookEntryNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handlePhotobookEntryNotFoundException(
+            PhotobookEntryNotFoundException ex, HttpServletRequest request) {
+
+        log.error("Photobook entry not found: {}", ex.getMessage());
+
+        Map<String, Object> details = new HashMap<>();
+        if (ex.getEntryId() != null) {
+            details.put("entryId", ex.getEntryId());
+        }
+
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            "Not Found",
+            ex.getMessage(),
+            request.getRequestURI(),
+            details
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    /**
      * 프레임 콜라보를 찾을 수 없는 경우
      */
     @ExceptionHandler(FrameCollabNotFoundException.class)

--- a/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
@@ -51,6 +51,31 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 콜라보 후보를 찾을 수 없는 경우
+     */
+    @ExceptionHandler(CollabCandidateNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCollabCandidateNotFoundException(
+            CollabCandidateNotFoundException ex, HttpServletRequest request) {
+
+        log.error("Collab candidate not found: {}", ex.getMessage());
+
+        Map<String, Object> details = new HashMap<>();
+        if (ex.getCandidateId() != null) {
+            details.put("candidateId", ex.getCandidateId());
+        }
+
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            "Not Found",
+            ex.getMessage(),
+            request.getRequestURI(),
+            details
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    /**
      * 포토북 사진을 찾을 수 없는 경우
      */
     @ExceptionHandler(PhotobookEntryNotFoundException.class)

--- a/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
@@ -51,6 +51,31 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * 프레임 콜라보를 찾을 수 없는 경우
+     */
+    @ExceptionHandler(FrameCollabNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleFrameCollabNotFoundException(
+            FrameCollabNotFoundException ex, HttpServletRequest request) {
+
+        log.error("FrameCollab not found: {}", ex.getMessage());
+
+        Map<String, Object> details = new HashMap<>();
+        if (ex.getFrameCollabId() != null) {
+            details.put("frameCollabId", ex.getFrameCollabId());
+        }
+
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.NOT_FOUND.value(),
+            "Not Found",
+            ex.getMessage(),
+            request.getRequestURI(),
+            details
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    /**
      * @Validated 기반 파라미터 검증 실패 (예: @RequestParam @Min/@Max)
      */
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/com/min/chalkakserver/exception/PhotobookEntryNotFoundException.java
+++ b/src/main/java/com/min/chalkakserver/exception/PhotobookEntryNotFoundException.java
@@ -1,0 +1,14 @@
+package com.min.chalkakserver.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PhotobookEntryNotFoundException extends RuntimeException {
+
+    private final Long entryId;
+
+    public PhotobookEntryNotFoundException(Long entryId) {
+        super(String.format("포토북 사진을 찾을 수 없습니다. ID: %d", entryId));
+        this.entryId = entryId;
+    }
+}

--- a/src/main/java/com/min/chalkakserver/repository/CollabCandidateRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/CollabCandidateRepository.java
@@ -1,0 +1,14 @@
+package com.min.chalkakserver.repository;
+
+import com.min.chalkakserver.entity.CollabCandidate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CollabCandidateRepository extends JpaRepository<CollabCandidate, Long> {
+
+    Page<CollabCandidate> findByStatusOrderByCreatedAtDesc(
+            CollabCandidate.CandidateStatus status, Pageable pageable);
+
+    Page<CollabCandidate> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/src/main/java/com/min/chalkakserver/repository/FrameAvailabilityReportRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/FrameAvailabilityReportRepository.java
@@ -1,0 +1,22 @@
+package com.min.chalkakserver.repository;
+
+import com.min.chalkakserver.entity.FrameAvailabilityReport;
+import com.min.chalkakserver.entity.FrameCollab;
+import com.min.chalkakserver.entity.PhotoBooth;
+import com.min.chalkakserver.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface FrameAvailabilityReportRepository extends JpaRepository<FrameAvailabilityReport, Long> {
+
+    List<FrameAvailabilityReport> findByFrameCollabIdAndPhotoBoothIdAndCreatedAtAfterOrderByCreatedAtDesc(
+            Long frameCollabId, Long photoBoothId, LocalDateTime cutoff);
+
+    List<FrameAvailabilityReport> findByFrameCollabIdAndCreatedAtAfterOrderByCreatedAtDesc(
+            Long frameCollabId, LocalDateTime cutoff);
+
+    boolean existsByUserAndFrameCollabAndPhotoBoothAndCreatedAtAfter(
+            User user, FrameCollab frameCollab, PhotoBooth photoBooth, LocalDateTime cutoff);
+}

--- a/src/main/java/com/min/chalkakserver/repository/FrameCollabRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/FrameCollabRepository.java
@@ -1,0 +1,42 @@
+package com.min.chalkakserver.repository;
+
+import com.min.chalkakserver.entity.FrameCollab;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface FrameCollabRepository extends JpaRepository<FrameCollab, Long> {
+
+    @Query("SELECT fc FROM FrameCollab fc " +
+           "WHERE fc.startDate <= :today AND fc.endDate >= :today " +
+           "ORDER BY fc.endDate ASC")
+    Page<FrameCollab> findActive(@Param("today") LocalDate today, Pageable pageable);
+
+    @Query("SELECT fc FROM FrameCollab fc " +
+           "WHERE fc.startDate > :today " +
+           "ORDER BY fc.startDate ASC")
+    Page<FrameCollab> findUpcoming(@Param("today") LocalDate today, Pageable pageable);
+
+    @Query("SELECT fc FROM FrameCollab fc " +
+           "WHERE fc.endDate < :today " +
+           "ORDER BY fc.endDate DESC")
+    Page<FrameCollab> findEnded(@Param("today") LocalDate today, Pageable pageable);
+
+    @Query("SELECT DISTINCT fc FROM FrameCollab fc " +
+           "JOIN fc.photoBooths pb " +
+           "WHERE pb.id = :photoBoothId AND fc.endDate >= :today " +
+           "ORDER BY fc.startDate ASC")
+    List<FrameCollab> findCurrentByPhotoBoothId(@Param("photoBoothId") Long photoBoothId,
+                                                @Param("today") LocalDate today);
+
+    @Query("SELECT fc FROM FrameCollab fc " +
+           "LEFT JOIN FETCH fc.photoBooths " +
+           "WHERE fc.id = :id")
+    Optional<FrameCollab> findByIdWithBooths(@Param("id") Long id);
+}

--- a/src/main/java/com/min/chalkakserver/repository/FrameCollabRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/FrameCollabRepository.java
@@ -39,4 +39,6 @@ public interface FrameCollabRepository extends JpaRepository<FrameCollab, Long> 
            "LEFT JOIN FETCH fc.photoBooths " +
            "WHERE fc.id = :id")
     Optional<FrameCollab> findByIdWithBooths(@Param("id") Long id);
+
+    boolean existsByIdAndPhotoBoothsId(Long id, Long photoBoothId);
 }

--- a/src/main/java/com/min/chalkakserver/repository/PhotobookEntryRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/PhotobookEntryRepository.java
@@ -1,0 +1,31 @@
+package com.min.chalkakserver.repository;
+
+import com.min.chalkakserver.entity.PhotobookEntry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PhotobookEntryRepository extends JpaRepository<PhotobookEntry, Long> {
+
+    Page<PhotobookEntry> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    Page<PhotobookEntry> findByUserIdAndFrameCollabIdOrderByCreatedAtDesc(
+            Long userId, Long frameCollabId, Pageable pageable);
+
+    long countByUserId(Long userId);
+
+    @Query("SELECT pe.frameCollab.id AS collabId, COUNT(pe) AS photoCount " +
+           "FROM PhotobookEntry pe " +
+           "WHERE pe.user.id = :userId AND pe.frameCollab IS NOT NULL " +
+           "GROUP BY pe.frameCollab.id")
+    List<CollabPhotoCount> countByUserGroupedByCollab(@Param("userId") Long userId);
+
+    interface CollabPhotoCount {
+        Long getCollabId();
+        Long getPhotoCount();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/service/CollabCandidateService.java
+++ b/src/main/java/com/min/chalkakserver/service/CollabCandidateService.java
@@ -1,0 +1,130 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateApproveRequestDto;
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateRequestDto;
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabDetailResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabRequestDto;
+import com.min.chalkakserver.entity.CollabCandidate;
+import com.min.chalkakserver.exception.CollabCandidateNotFoundException;
+import com.min.chalkakserver.repository.CollabCandidateRepository;
+import com.min.chalkakserver.util.CollabTextParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CollabCandidateService {
+
+    private final CollabCandidateRepository collabCandidateRepository;
+    private final FrameCollabService frameCollabService;
+
+    @Transactional
+    public CollabCandidateResponseDto createCandidate(CollabCandidateRequestDto request) {
+        CollabTextParser.ParsedCollab parsed =
+                CollabTextParser.parse(request.getRawText(), LocalDate.now());
+
+        CollabCandidate candidate = CollabCandidate.builder()
+                .sourceUrl(request.getSourceUrl())
+                .rawText(request.getRawText())
+                .title(parsed.title())
+                .brand(parsed.brand())
+                .artistName(parsed.artistName())
+                .startDate(parsed.startDate())
+                .endDate(parsed.endDate())
+                .build();
+
+        CollabCandidate saved = collabCandidateRepository.save(candidate);
+        log.info("Collab candidate created: id={}, title={}, brand={}",
+                saved.getId(), saved.getTitle(), saved.getBrand());
+        return CollabCandidateResponseDto.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponseDto<CollabCandidateResponseDto> getCandidates(String status, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<CollabCandidate> candidatePage;
+        if (status == null || status.isBlank() || "all".equalsIgnoreCase(status)) {
+            candidatePage = collabCandidateRepository.findAllByOrderByCreatedAtDesc(pageable);
+        } else {
+            CollabCandidate.CandidateStatus candidateStatus;
+            try {
+                candidateStatus = CollabCandidate.CandidateStatus.valueOf(status.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException(
+                        "status는 pending, approved, rejected, all 중 하나여야 합니다.");
+            }
+            candidatePage = collabCandidateRepository
+                    .findByStatusOrderByCreatedAtDesc(candidateStatus, pageable);
+        }
+        return PagedResponseDto.from(candidatePage.map(CollabCandidateResponseDto::from));
+    }
+
+    @Transactional
+    public FrameCollabDetailResponseDto approveCandidate(Long candidateId,
+                                                         CollabCandidateApproveRequestDto request) {
+        CollabCandidate candidate = collabCandidateRepository.findById(candidateId)
+                .orElseThrow(() -> new CollabCandidateNotFoundException(candidateId));
+
+        if (candidate.getStatus() != CollabCandidate.CandidateStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 후보만 승인할 수 있습니다.");
+        }
+
+        CollabCandidateApproveRequestDto overrides = request != null
+                ? request
+                : CollabCandidateApproveRequestDto.builder().build();
+
+        String title = firstNonNull(overrides.getTitle(), candidate.getTitle());
+        LocalDate startDate = firstNonNull(overrides.getStartDate(), candidate.getStartDate());
+        LocalDate endDate = firstNonNull(overrides.getEndDate(), candidate.getEndDate());
+
+        if (title == null || startDate == null || endDate == null) {
+            throw new IllegalArgumentException(
+                    "승인하려면 제목/시작일/종료일이 필요합니다. 누락된 값을 함께 보내주세요.");
+        }
+
+        FrameCollabRequestDto collabRequest = FrameCollabRequestDto.builder()
+                .title(title)
+                .brand(firstNonNull(overrides.getBrand(), candidate.getBrand()))
+                .artistName(firstNonNull(overrides.getArtistName(), candidate.getArtistName()))
+                .description(overrides.getDescription())
+                .imageUrl(overrides.getImageUrl())
+                .startDate(startDate)
+                .endDate(endDate)
+                .photoBoothIds(overrides.getPhotoBoothIds())
+                .build();
+
+        FrameCollabDetailResponseDto created = frameCollabService.createCollab(collabRequest);
+        candidate.approve(created.getId());
+        log.info("Collab candidate approved: candidateId={}, frameCollabId={}",
+                candidateId, created.getId());
+        return created;
+    }
+
+    @Transactional
+    public CollabCandidateResponseDto rejectCandidate(Long candidateId) {
+        CollabCandidate candidate = collabCandidateRepository.findById(candidateId)
+                .orElseThrow(() -> new CollabCandidateNotFoundException(candidateId));
+
+        if (candidate.getStatus() != CollabCandidate.CandidateStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 후보만 거절할 수 있습니다.");
+        }
+
+        candidate.reject();
+        log.info("Collab candidate rejected: candidateId={}", candidateId);
+        return CollabCandidateResponseDto.from(candidate);
+    }
+
+    private static <T> T firstNonNull(T first, T second) {
+        return first != null ? first : second;
+    }
+}

--- a/src/main/java/com/min/chalkakserver/service/FrameAvailabilityService.java
+++ b/src/main/java/com/min/chalkakserver/service/FrameAvailabilityService.java
@@ -1,0 +1,180 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityReportRequestDto;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityReportResponseDto;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityResponseDto;
+import com.min.chalkakserver.entity.FrameAvailabilityReport;
+import com.min.chalkakserver.entity.FrameCollab;
+import com.min.chalkakserver.entity.PhotoBooth;
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.exception.DuplicateAvailabilityReportException;
+import com.min.chalkakserver.exception.FrameCollabNotFoundException;
+import com.min.chalkakserver.exception.PhotoBoothNotFoundException;
+import com.min.chalkakserver.repository.FrameAvailabilityReportRepository;
+import com.min.chalkakserver.repository.FrameCollabRepository;
+import com.min.chalkakserver.repository.PhotoBoothRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FrameAvailabilityService {
+
+    private static final int AGGREGATION_WINDOW_HOURS = 24;
+    private static final int REPORT_COOLDOWN_MINUTES = 60;
+    // 재고는 혼잡도보다 천천히 변하므로 감쇠 시간 상수를 6시간으로 둔다
+    private static final double DECAY_TIME_CONSTANT_MINUTES = 360.0;
+    private static final double AVAILABLE_THRESHOLD = 0.5;
+
+    private final FrameAvailabilityReportRepository availabilityReportRepository;
+    private final FrameCollabRepository frameCollabRepository;
+    private final PhotoBoothRepository photoBoothRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public FrameAvailabilityResponseDto getAvailability(Long frameCollabId, Long photoBoothId) {
+        validateCollabBooth(frameCollabId, photoBoothId);
+
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(AGGREGATION_WINDOW_HOURS);
+        List<FrameAvailabilityReport> reports = availabilityReportRepository
+                .findByFrameCollabIdAndPhotoBoothIdAndCreatedAtAfterOrderByCreatedAtDesc(
+                        frameCollabId, photoBoothId, cutoff);
+
+        return aggregate(frameCollabId, photoBoothId, reports);
+    }
+
+    @Transactional(readOnly = true)
+    public List<FrameAvailabilityResponseDto> getCollabAvailability(Long frameCollabId) {
+        FrameCollab collab = frameCollabRepository.findByIdWithBooths(frameCollabId)
+                .orElseThrow(() -> new FrameCollabNotFoundException(frameCollabId));
+
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(AGGREGATION_WINDOW_HOURS);
+        Map<Long, List<FrameAvailabilityReport>> reportsByBooth = availabilityReportRepository
+                .findByFrameCollabIdAndCreatedAtAfterOrderByCreatedAtDesc(frameCollabId, cutoff)
+                .stream()
+                .collect(Collectors.groupingBy(report -> report.getPhotoBooth().getId()));
+
+        return collab.getPhotoBooths().stream()
+                .sorted((a, b) -> Long.compare(a.getId(), b.getId()))
+                .map(booth -> aggregate(frameCollabId, booth.getId(),
+                        reportsByBooth.getOrDefault(booth.getId(), List.of())))
+                .toList();
+    }
+
+    @Transactional
+    public FrameAvailabilityReportResponseDto submitReport(Long userId, Long frameCollabId, Long photoBoothId,
+                                                           FrameAvailabilityReportRequestDto request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        FrameCollab collab = frameCollabRepository.findById(frameCollabId)
+                .orElseThrow(() -> new FrameCollabNotFoundException(frameCollabId));
+        PhotoBooth photoBooth = photoBoothRepository.findById(photoBoothId)
+                .orElseThrow(() -> new PhotoBoothNotFoundException(photoBoothId));
+
+        validateCollabBooth(frameCollabId, photoBoothId);
+
+        if (collab.getStatus(LocalDate.now()) != FrameCollab.CollabStatus.ACTIVE) {
+            throw new IllegalArgumentException("진행 중인 콜라보만 재고 제보가 가능합니다.");
+        }
+
+        LocalDateTime cooldownCutoff = LocalDateTime.now().minusMinutes(REPORT_COOLDOWN_MINUTES);
+        boolean alreadyReported = availabilityReportRepository
+                .existsByUserAndFrameCollabAndPhotoBoothAndCreatedAtAfter(user, collab, photoBooth, cooldownCutoff);
+        if (alreadyReported) {
+            throw new DuplicateAvailabilityReportException(frameCollabId, photoBoothId);
+        }
+
+        FrameAvailabilityReport report = FrameAvailabilityReport.builder()
+                .user(user)
+                .frameCollab(collab)
+                .photoBooth(photoBooth)
+                .availabilityStatus(request.getAvailabilityStatus())
+                .build();
+
+        FrameAvailabilityReport saved = availabilityReportRepository.save(report);
+        log.info("Frame availability report submitted: userId={}, collabId={}, boothId={}, status={}",
+                userId, frameCollabId, photoBoothId, request.getAvailabilityStatus());
+
+        return FrameAvailabilityReportResponseDto.builder()
+                .frameCollabId(frameCollabId)
+                .photoBoothId(photoBoothId)
+                .message("재고 제보가 반영되었습니다.")
+                .submittedAt(saved.getCreatedAt())
+                .build();
+    }
+
+    private void validateCollabBooth(Long frameCollabId, Long photoBoothId) {
+        if (!frameCollabRepository.existsById(frameCollabId)) {
+            throw new FrameCollabNotFoundException(frameCollabId);
+        }
+        if (!frameCollabRepository.existsByIdAndPhotoBoothsId(frameCollabId, photoBoothId)) {
+            throw new IllegalArgumentException("해당 콜라보의 입고 매장이 아닙니다.");
+        }
+    }
+
+    private FrameAvailabilityResponseDto aggregate(Long frameCollabId, Long photoBoothId,
+                                                   List<FrameAvailabilityReport> reports) {
+        if (reports.isEmpty()) {
+            return FrameAvailabilityResponseDto.builder()
+                    .frameCollabId(frameCollabId)
+                    .photoBoothId(photoBoothId)
+                    .status(FrameAvailabilityResponseDto.ResultStatus.UNKNOWN)
+                    .confidenceLevel(FrameAvailabilityResponseDto.ConfidenceLevel.LOW)
+                    .sampleSize(0)
+                    .message("아직 재고 제보가 없어요.")
+                    .build();
+        }
+
+        double weightedScore = calculateWeightedScore(reports);
+        FrameAvailabilityResponseDto.ResultStatus status = weightedScore >= AVAILABLE_THRESHOLD
+                ? FrameAvailabilityResponseDto.ResultStatus.AVAILABLE
+                : FrameAvailabilityResponseDto.ResultStatus.SOLD_OUT;
+        FrameAvailabilityResponseDto.ConfidenceLevel confidence = mapConfidence(reports.size());
+
+        return FrameAvailabilityResponseDto.builder()
+                .frameCollabId(frameCollabId)
+                .photoBoothId(photoBoothId)
+                .status(status)
+                .confidenceLevel(confidence)
+                .sampleSize(reports.size())
+                .lastUpdatedAt(reports.get(0).getCreatedAt())
+                .message(String.format("최근 %d건 제보 기준 %s (신뢰도: %s)",
+                        reports.size(), status.name(), confidence.name()))
+                .build();
+    }
+
+    private double calculateWeightedScore(List<FrameAvailabilityReport> reports) {
+        LocalDateTime now = LocalDateTime.now();
+        double weightedSum = 0.0;
+        double weightTotal = 0.0;
+
+        for (FrameAvailabilityReport report : reports) {
+            long minutesAgo = Math.max(0, Duration.between(report.getCreatedAt(), now).toMinutes());
+            double weight = Math.exp(-minutesAgo / DECAY_TIME_CONSTANT_MINUTES);
+            weightedSum += report.getAvailabilityStatus().getScore() * weight;
+            weightTotal += weight;
+        }
+        return weightTotal == 0.0 ? 0.0 : weightedSum / weightTotal;
+    }
+
+    private FrameAvailabilityResponseDto.ConfidenceLevel mapConfidence(int sampleSize) {
+        if (sampleSize >= 6) {
+            return FrameAvailabilityResponseDto.ConfidenceLevel.HIGH;
+        } else if (sampleSize >= 3) {
+            return FrameAvailabilityResponseDto.ConfidenceLevel.MEDIUM;
+        } else {
+            return FrameAvailabilityResponseDto.ConfidenceLevel.LOW;
+        }
+    }
+}

--- a/src/main/java/com/min/chalkakserver/service/FrameCollabService.java
+++ b/src/main/java/com/min/chalkakserver/service/FrameCollabService.java
@@ -1,0 +1,135 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabDetailResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabRequestDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabResponseDto;
+import com.min.chalkakserver.entity.FrameCollab;
+import com.min.chalkakserver.entity.PhotoBooth;
+import com.min.chalkakserver.exception.FrameCollabNotFoundException;
+import com.min.chalkakserver.exception.PhotoBoothNotFoundException;
+import com.min.chalkakserver.repository.FrameCollabRepository;
+import com.min.chalkakserver.repository.PhotoBoothRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FrameCollabService {
+
+    private final FrameCollabRepository frameCollabRepository;
+    private final PhotoBoothRepository photoBoothRepository;
+
+    @Transactional(readOnly = true)
+    public PagedResponseDto<FrameCollabResponseDto> getCollabs(String status, int page, int size) {
+        LocalDate today = LocalDate.now();
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<FrameCollab> collabPage = switch (status) {
+            case "upcoming" -> frameCollabRepository.findUpcoming(today, pageable);
+            case "ended" -> frameCollabRepository.findEnded(today, pageable);
+            default -> frameCollabRepository.findActive(today, pageable);
+        };
+
+        return PagedResponseDto.from(collabPage.map(collab -> FrameCollabResponseDto.from(collab, today)));
+    }
+
+    @Transactional(readOnly = true)
+    public FrameCollabDetailResponseDto getCollab(Long id) {
+        FrameCollab collab = frameCollabRepository.findByIdWithBooths(id)
+                .orElseThrow(() -> new FrameCollabNotFoundException(id));
+        return FrameCollabDetailResponseDto.from(collab, LocalDate.now());
+    }
+
+    @Transactional(readOnly = true)
+    public List<FrameCollabResponseDto> getCollabsByPhotoBooth(Long photoBoothId) {
+        if (!photoBoothRepository.existsById(photoBoothId)) {
+            throw new PhotoBoothNotFoundException(photoBoothId);
+        }
+        LocalDate today = LocalDate.now();
+        return frameCollabRepository.findCurrentByPhotoBoothId(photoBoothId, today).stream()
+                .map(collab -> FrameCollabResponseDto.from(collab, today))
+                .toList();
+    }
+
+    @Transactional
+    public FrameCollabDetailResponseDto createCollab(FrameCollabRequestDto request) {
+        FrameCollab collab = FrameCollab.builder()
+                .title(request.getTitle())
+                .brand(request.getBrand())
+                .artistName(request.getArtistName())
+                .description(request.getDescription())
+                .imageUrl(request.getImageUrl())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .build();
+
+        if (request.getPhotoBoothIds() != null && !request.getPhotoBoothIds().isEmpty()) {
+            collab.updatePhotoBooths(resolveBooths(request.getPhotoBoothIds()));
+        }
+
+        FrameCollab saved = frameCollabRepository.save(collab);
+        log.info("FrameCollab created: id={}, title={}", saved.getId(), saved.getTitle());
+        return FrameCollabDetailResponseDto.from(saved, LocalDate.now());
+    }
+
+    @Transactional
+    public FrameCollabDetailResponseDto updateCollab(Long id, FrameCollabRequestDto request) {
+        FrameCollab collab = frameCollabRepository.findByIdWithBooths(id)
+                .orElseThrow(() -> new FrameCollabNotFoundException(id));
+
+        collab.update(request.getTitle(), request.getBrand(), request.getArtistName(),
+                request.getDescription(), request.getImageUrl(),
+                request.getStartDate(), request.getEndDate());
+
+        if (request.getPhotoBoothIds() != null) {
+            collab.updatePhotoBooths(resolveBooths(request.getPhotoBoothIds()));
+        }
+
+        log.info("FrameCollab updated: id={}", id);
+        return FrameCollabDetailResponseDto.from(collab, LocalDate.now());
+    }
+
+    @Transactional
+    public void deleteCollab(Long id) {
+        FrameCollab collab = frameCollabRepository.findById(id)
+                .orElseThrow(() -> new FrameCollabNotFoundException(id));
+        frameCollabRepository.delete(collab);
+        log.info("FrameCollab deleted: id={}", id);
+    }
+
+    @Transactional
+    public FrameCollabDetailResponseDto setPhotoBooths(Long id, List<Long> photoBoothIds) {
+        FrameCollab collab = frameCollabRepository.findByIdWithBooths(id)
+                .orElseThrow(() -> new FrameCollabNotFoundException(id));
+        collab.updatePhotoBooths(resolveBooths(photoBoothIds));
+        log.info("FrameCollab booths updated: id={}, boothCount={}", id, photoBoothIds.size());
+        return FrameCollabDetailResponseDto.from(collab, LocalDate.now());
+    }
+
+    private Set<PhotoBooth> resolveBooths(List<Long> photoBoothIds) {
+        List<PhotoBooth> booths = photoBoothRepository.findAllById(photoBoothIds);
+        if (booths.size() != Set.copyOf(photoBoothIds).size()) {
+            Set<Long> foundIds = new HashSet<>();
+            for (PhotoBooth booth : booths) {
+                foundIds.add(booth.getId());
+            }
+            List<Long> missing = photoBoothIds.stream()
+                    .filter(boothId -> !foundIds.contains(boothId))
+                    .toList();
+            throw new PhotoBoothNotFoundException("존재하지 않는 사진관이 포함되어 있습니다. ID: " + missing);
+        }
+        return new HashSet<>(booths);
+    }
+}

--- a/src/main/java/com/min/chalkakserver/service/PhotobookService.java
+++ b/src/main/java/com/min/chalkakserver/service/PhotobookService.java
@@ -1,0 +1,136 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.photobook.PhotobookCollectionResponseDto;
+import com.min.chalkakserver.dto.photobook.PhotobookEntryRequestDto;
+import com.min.chalkakserver.dto.photobook.PhotobookEntryResponseDto;
+import com.min.chalkakserver.entity.FrameCollab;
+import com.min.chalkakserver.entity.PhotoBooth;
+import com.min.chalkakserver.entity.PhotobookEntry;
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.exception.FrameCollabNotFoundException;
+import com.min.chalkakserver.exception.PhotoBoothNotFoundException;
+import com.min.chalkakserver.exception.PhotobookEntryNotFoundException;
+import com.min.chalkakserver.repository.FrameCollabRepository;
+import com.min.chalkakserver.repository.PhotoBoothRepository;
+import com.min.chalkakserver.repository.PhotobookEntryRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotobookService {
+
+    private final PhotobookEntryRepository photobookEntryRepository;
+    private final FrameCollabRepository frameCollabRepository;
+    private final PhotoBoothRepository photoBoothRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public PhotobookEntryResponseDto createEntry(Long userId, PhotobookEntryRequestDto request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException("사용자를 찾을 수 없습니다."));
+
+        FrameCollab collab = null;
+        if (request.getFrameCollabId() != null) {
+            collab = frameCollabRepository.findById(request.getFrameCollabId())
+                    .orElseThrow(() -> new FrameCollabNotFoundException(request.getFrameCollabId()));
+        }
+
+        PhotoBooth booth = null;
+        if (request.getPhotoBoothId() != null) {
+            booth = photoBoothRepository.findById(request.getPhotoBoothId())
+                    .orElseThrow(() -> new PhotoBoothNotFoundException(request.getPhotoBoothId()));
+        }
+
+        PhotobookEntry entry = PhotobookEntry.builder()
+                .user(user)
+                .frameCollab(collab)
+                .photoBooth(booth)
+                .imageUrl(request.getImageUrl())
+                .takenAt(request.getTakenAt())
+                .memo(request.getMemo())
+                .build();
+
+        PhotobookEntry saved = photobookEntryRepository.save(entry);
+        log.info("Photobook entry created: userId={}, entryId={}, collabId={}",
+                userId, saved.getId(), request.getFrameCollabId());
+        return PhotobookEntryResponseDto.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponseDto<PhotobookEntryResponseDto> getMyEntries(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<PhotobookEntry> entryPage = photobookEntryRepository
+                .findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        return PagedResponseDto.from(entryPage.map(PhotobookEntryResponseDto::from));
+    }
+
+    @Transactional(readOnly = true)
+    public PagedResponseDto<PhotobookEntryResponseDto> getMyEntriesByCollab(
+            Long userId, Long frameCollabId, int page, int size) {
+        if (!frameCollabRepository.existsById(frameCollabId)) {
+            throw new FrameCollabNotFoundException(frameCollabId);
+        }
+        Pageable pageable = PageRequest.of(page, size);
+        Page<PhotobookEntry> entryPage = photobookEntryRepository
+                .findByUserIdAndFrameCollabIdOrderByCreatedAtDesc(userId, frameCollabId, pageable);
+        return PagedResponseDto.from(entryPage.map(PhotobookEntryResponseDto::from));
+    }
+
+    @Transactional
+    public void deleteEntry(Long userId, Long entryId) {
+        PhotobookEntry entry = photobookEntryRepository.findById(entryId)
+                .orElseThrow(() -> new PhotobookEntryNotFoundException(entryId));
+
+        if (!entry.getUser().getId().equals(userId)) {
+            throw new AuthException("포토북 사진을 삭제할 권한이 없습니다.");
+        }
+
+        photobookEntryRepository.delete(entry);
+        log.info("Photobook entry deleted: userId={}, entryId={}", userId, entryId);
+    }
+
+    @Transactional(readOnly = true)
+    public PhotobookCollectionResponseDto getMyCollection(Long userId) {
+        LocalDate today = LocalDate.now();
+
+        Map<Long, Long> countByCollab = photobookEntryRepository.countByUserGroupedByCollab(userId)
+                .stream()
+                .collect(Collectors.toMap(
+                        PhotobookEntryRepository.CollabPhotoCount::getCollabId,
+                        PhotobookEntryRepository.CollabPhotoCount::getPhotoCount));
+
+        List<PhotobookCollectionResponseDto.CollectionItemDto> items = frameCollabRepository
+                .findAll(Sort.by(Sort.Direction.DESC, "startDate"))
+                .stream()
+                .map(collab -> PhotobookCollectionResponseDto.CollectionItemDto.from(
+                        collab, today, countByCollab.getOrDefault(collab.getId(), 0L)))
+                .toList();
+
+        int collected = (int) items.stream()
+                .filter(PhotobookCollectionResponseDto.CollectionItemDto::isCollected)
+                .count();
+
+        return PhotobookCollectionResponseDto.builder()
+                .totalCollabs(items.size())
+                .collectedCollabs(collected)
+                .totalPhotos(photobookEntryRepository.countByUserId(userId))
+                .items(items)
+                .build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/util/CollabTextParser.java
+++ b/src/main/java/com/min/chalkakserver/util/CollabTextParser.java
@@ -1,0 +1,136 @@
+package com.min.chalkakserver.util;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 콜라보 공지 텍스트에서 제목/브랜드/아티스트/기간을 휴리스틱으로 추출하는 파서.
+ * 완벽한 추출이 목적이 아니라 어드민 검토용 초안 생성이 목적이다.
+ */
+public final class CollabTextParser {
+
+    private static final List<String> KNOWN_BRANDS = List.of(
+            "인생네컷", "포토이즘", "하루필름", "포토그레이", "포토매틱",
+            "모노맨션", "포토시그니처", "셀픽스", "비룸", "돈룩업", "포토드링크",
+            "플랜비스튜디오", "포토하임", "금달스튜디오", "홍대네컷", "포토오브제"
+    );
+
+    // 연도 포함 날짜: 2026.06.01 / 2026-06-01 / 2026년 6월 1일
+    private static final Pattern FULL_DATE = Pattern.compile(
+            "(\\d{4})\\s*[.\\-/년]\\s*(\\d{1,2})\\s*[.\\-/월]\\s*(\\d{1,2})\\s*일?");
+
+    // 연도 생략 날짜: 6월 1일 / 06.01 / 6/1
+    private static final Pattern SHORT_DATE = Pattern.compile(
+            "(?<!\\d)(\\d{1,2})\\s*[./월]\\s*(\\d{1,2})\\s*일?(?![./\\d])");
+
+    private static final Pattern COLLAB_SEPARATOR = Pattern.compile("\\s*[xX×]\\s*");
+
+    private CollabTextParser() {
+    }
+
+    public record ParsedCollab(String title, String brand, String artistName,
+                               LocalDate startDate, LocalDate endDate) {
+    }
+
+    public static ParsedCollab parse(String rawText, LocalDate referenceDate) {
+        String text = rawText == null ? "" : rawText.strip();
+
+        String title = extractTitle(text);
+        String brand = extractBrand(text);
+        String artistName = extractArtistName(title, brand);
+        List<LocalDate> dates = extractDates(text, referenceDate);
+
+        LocalDate startDate = dates.size() >= 1 ? dates.get(0) : null;
+        LocalDate endDate = dates.size() >= 2 ? dates.get(1) : null;
+        // 12월 시작 ~ 1월 종료처럼 연도 생략 표기에서 종료일이 시작일보다 앞서면 이듬해로 보정
+        if (startDate != null && endDate != null && endDate.isBefore(startDate)) {
+            endDate = endDate.plusYears(1);
+        }
+
+        return new ParsedCollab(title, brand, artistName, startDate, endDate);
+    }
+
+    private static String extractTitle(String text) {
+        for (String line : text.split("\\R")) {
+            String trimmed = line.strip();
+            if (!trimmed.isEmpty()) {
+                return trimmed.length() > 150 ? trimmed.substring(0, 150) : trimmed;
+            }
+        }
+        return null;
+    }
+
+    private static String extractBrand(String text) {
+        for (String brand : KNOWN_BRANDS) {
+            if (text.contains(brand)) {
+                return brand;
+            }
+        }
+        return null;
+    }
+
+    private static String extractArtistName(String title, String brand) {
+        if (title == null || brand == null || !title.contains(brand)) {
+            return null;
+        }
+        String[] parts = COLLAB_SEPARATOR.split(title);
+        if (parts.length < 2) {
+            return null;
+        }
+        for (String part : parts) {
+            String candidate = part.strip();
+            if (!candidate.isEmpty() && !candidate.contains(brand)) {
+                return candidate.length() > 100 ? candidate.substring(0, 100) : candidate;
+            }
+        }
+        return null;
+    }
+
+    private static List<LocalDate> extractDates(String text, LocalDate referenceDate) {
+        List<LocalDate> dates = new ArrayList<>();
+        StringBuilder remaining = new StringBuilder(text);
+
+        Matcher full = FULL_DATE.matcher(text);
+        while (full.find() && dates.size() < 2) {
+            LocalDate parsed = safeDate(
+                    Integer.parseInt(full.group(1)),
+                    Integer.parseInt(full.group(2)),
+                    Integer.parseInt(full.group(3)));
+            if (parsed != null) {
+                dates.add(parsed);
+                blankOut(remaining, full.start(), full.end());
+            }
+        }
+
+        if (dates.size() < 2) {
+            Matcher shortDate = SHORT_DATE.matcher(remaining.toString());
+            while (shortDate.find() && dates.size() < 2) {
+                LocalDate parsed = safeDate(
+                        referenceDate.getYear(),
+                        Integer.parseInt(shortDate.group(1)),
+                        Integer.parseInt(shortDate.group(2)));
+                if (parsed != null) {
+                    dates.add(parsed);
+                }
+            }
+        }
+        return dates;
+    }
+
+    private static void blankOut(StringBuilder text, int start, int end) {
+        for (int i = start; i < end; i++) {
+            text.setCharAt(i, ' ');
+        }
+    }
+
+    private static LocalDate safeDate(int year, int month, int day) {
+        try {
+            return LocalDate.of(year, month, day);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/min/chalkakserver/controller/AdminControllerTest.java
+++ b/src/test/java/com/min/chalkakserver/controller/AdminControllerTest.java
@@ -12,6 +12,7 @@ import com.min.chalkakserver.entity.User;
 import com.min.chalkakserver.security.CustomUserDetails;
 import com.min.chalkakserver.security.jwt.JwtAuthenticationFilter;
 import com.min.chalkakserver.service.AdminService;
+import com.min.chalkakserver.service.CollabCandidateService;
 import com.min.chalkakserver.service.FrameCollabService;
 import com.min.chalkakserver.service.TagService;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +63,9 @@ class AdminControllerTest {
 
     @MockBean
     private FrameCollabService frameCollabService;
+
+    @MockBean
+    private CollabCandidateService collabCandidateService;
 
     @MockBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/test/java/com/min/chalkakserver/controller/AdminControllerTest.java
+++ b/src/test/java/com/min/chalkakserver/controller/AdminControllerTest.java
@@ -12,6 +12,7 @@ import com.min.chalkakserver.entity.User;
 import com.min.chalkakserver.security.CustomUserDetails;
 import com.min.chalkakserver.security.jwt.JwtAuthenticationFilter;
 import com.min.chalkakserver.service.AdminService;
+import com.min.chalkakserver.service.FrameCollabService;
 import com.min.chalkakserver.service.TagService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,6 +59,9 @@ class AdminControllerTest {
 
     @MockBean
     private TagService tagService;
+
+    @MockBean
+    private FrameCollabService frameCollabService;
 
     @MockBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/test/java/com/min/chalkakserver/controller/FrameAvailabilityControllerTest.java
+++ b/src/test/java/com/min/chalkakserver/controller/FrameAvailabilityControllerTest.java
@@ -1,0 +1,169 @@
+package com.min.chalkakserver.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityReportRequestDto;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityReportResponseDto;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityResponseDto;
+import com.min.chalkakserver.entity.FrameAvailabilityReport;
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.exception.DuplicateAvailabilityReportException;
+import com.min.chalkakserver.exception.GlobalExceptionHandler;
+import com.min.chalkakserver.security.CustomUserDetails;
+import com.min.chalkakserver.service.FrameAvailabilityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FrameAvailabilityController 테스트")
+class FrameAvailabilityControllerTest {
+
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+
+    @Mock
+    private FrameAvailabilityService frameAvailabilityService;
+
+    @InjectMocks
+    private FrameAvailabilityController frameAvailabilityController;
+
+    private CustomUserDetails userDetails;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        User testUser = User.builder()
+                .email("test@test.com")
+                .nickname("tester")
+                .provider(User.AuthProvider.EMAIL)
+                .providerId("test@test.com")
+                .role(User.Role.USER)
+                .build();
+        Field idField = User.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(testUser, 1L);
+
+        userDetails = new CustomUserDetails(testUser);
+
+        mockMvc = MockMvcBuilders.standaloneSetup(frameAvailabilityController)
+                .setCustomArgumentResolvers(new HandlerMethodArgumentResolver() {
+                    @Override
+                    public boolean supportsParameter(MethodParameter parameter) {
+                        return parameter.getParameterType().equals(CustomUserDetails.class);
+                    }
+
+                    @Override
+                    public Object resolveArgument(MethodParameter parameter,
+                            ModelAndViewContainer mavContainer,
+                            NativeWebRequest webRequest,
+                            WebDataBinderFactory binderFactory) {
+                        return userDetails;
+                    }
+                })
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    @DisplayName("GET /collab/{id}/booth/{id} - 매장 재고 상태를 반환한다")
+    void getAvailability() throws Exception {
+        given(frameAvailabilityService.getAvailability(1L, 10L))
+                .willReturn(FrameAvailabilityResponseDto.builder()
+                        .frameCollabId(1L)
+                        .photoBoothId(10L)
+                        .status(FrameAvailabilityResponseDto.ResultStatus.AVAILABLE)
+                        .confidenceLevel(FrameAvailabilityResponseDto.ConfidenceLevel.HIGH)
+                        .sampleSize(7)
+                        .build());
+
+        mockMvc.perform(get("/api/frame-availability/collab/1/booth/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.confidenceLevel").value("HIGH"))
+                .andExpect(jsonPath("$.sampleSize").value(7));
+    }
+
+    @Test
+    @DisplayName("GET /collab/{id} - 콜라보 전체 매장 재고 목록을 반환한다")
+    void getCollabAvailability() throws Exception {
+        given(frameAvailabilityService.getCollabAvailability(1L))
+                .willReturn(List.of(
+                        FrameAvailabilityResponseDto.builder()
+                                .frameCollabId(1L)
+                                .photoBoothId(10L)
+                                .status(FrameAvailabilityResponseDto.ResultStatus.SOLD_OUT)
+                                .confidenceLevel(FrameAvailabilityResponseDto.ConfidenceLevel.LOW)
+                                .sampleSize(1)
+                                .build()));
+
+        mockMvc.perform(get("/api/frame-availability/collab/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].photoBoothId").value(10))
+                .andExpect(jsonPath("$[0].status").value("SOLD_OUT"));
+    }
+
+    @Test
+    @DisplayName("POST /collab/{id}/booth/{id} - 재고 제보를 접수한다")
+    void submitReport() throws Exception {
+        given(frameAvailabilityService.submitReport(eq(1L), eq(1L), eq(10L), any()))
+                .willReturn(FrameAvailabilityReportResponseDto.builder()
+                        .frameCollabId(1L)
+                        .photoBoothId(10L)
+                        .message("재고 제보가 반영되었습니다.")
+                        .build());
+
+        FrameAvailabilityReportRequestDto request = FrameAvailabilityReportRequestDto.builder()
+                .availabilityStatus(FrameAvailabilityReport.AvailabilityStatus.SOLD_OUT)
+                .build();
+
+        mockMvc.perform(post("/api/frame-availability/collab/1/booth/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("재고 제보가 반영되었습니다."));
+    }
+
+    @Test
+    @DisplayName("POST - 쿨다운 중복 제보는 409를 반환한다")
+    void submitReport_Duplicate() throws Exception {
+        given(frameAvailabilityService.submitReport(eq(1L), eq(1L), eq(10L), any()))
+                .willThrow(new DuplicateAvailabilityReportException(1L, 10L));
+
+        FrameAvailabilityReportRequestDto request = FrameAvailabilityReportRequestDto.builder()
+                .availabilityStatus(FrameAvailabilityReport.AvailabilityStatus.AVAILABLE)
+                .build();
+
+        mockMvc.perform(post("/api/frame-availability/collab/1/booth/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.details.frameCollabId").value(1))
+                .andExpect(jsonPath("$.details.photoBoothId").value(10));
+    }
+}

--- a/src/test/java/com/min/chalkakserver/controller/FrameCollabControllerTest.java
+++ b/src/test/java/com/min/chalkakserver/controller/FrameCollabControllerTest.java
@@ -1,0 +1,117 @@
+package com.min.chalkakserver.controller;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabDetailResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabResponseDto;
+import com.min.chalkakserver.entity.FrameCollab;
+import com.min.chalkakserver.exception.FrameCollabNotFoundException;
+import com.min.chalkakserver.exception.GlobalExceptionHandler;
+import com.min.chalkakserver.service.FrameCollabService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FrameCollabController 테스트")
+class FrameCollabControllerTest {
+
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+
+    @Mock
+    private FrameCollabService frameCollabService;
+
+    @InjectMocks
+    private FrameCollabController frameCollabController;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(frameCollabController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    private FrameCollabResponseDto summaryDto() {
+        return FrameCollabResponseDto.builder()
+                .id(1L)
+                .title("뉴진스 X 인생네컷")
+                .brand("인생네컷")
+                .artistName("뉴진스")
+                .startDate(LocalDate.of(2026, 6, 1))
+                .endDate(LocalDate.of(2026, 6, 30))
+                .status(FrameCollab.CollabStatus.ACTIVE)
+                .photoBoothCount(3)
+                .build();
+    }
+
+    @Test
+    @DisplayName("GET /api/frame-collabs - 콜라보 피드를 반환한다")
+    void getCollabs() throws Exception {
+        given(frameCollabService.getCollabs(eq("active"), anyInt(), anyInt()))
+                .willReturn(PagedResponseDto.of(List.of(summaryDto())));
+
+        mockMvc.perform(get("/api/frame-collabs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].title").value("뉴진스 X 인생네컷"))
+                .andExpect(jsonPath("$.content[0].status").value("ACTIVE"))
+                .andExpect(jsonPath("$.content[0].photoBoothCount").value(3));
+    }
+
+    @Test
+    @DisplayName("GET /api/frame-collabs/{id} - 콜라보 상세를 반환한다")
+    void getCollab() throws Exception {
+        FrameCollabDetailResponseDto detail = FrameCollabDetailResponseDto.builder()
+                .id(1L)
+                .title("뉴진스 X 인생네컷")
+                .status(FrameCollab.CollabStatus.ACTIVE)
+                .photoBooths(List.of())
+                .build();
+        given(frameCollabService.getCollab(1L)).willReturn(detail);
+
+        mockMvc.perform(get("/api/frame-collabs/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.photoBooths").isArray());
+    }
+
+    @Test
+    @DisplayName("GET /api/frame-collabs/{id} - 없는 콜라보는 404를 반환한다")
+    void getCollab_NotFound() throws Exception {
+        given(frameCollabService.getCollab(99L)).willThrow(new FrameCollabNotFoundException(99L));
+
+        mockMvc.perform(get("/api/frame-collabs/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.details.frameCollabId").value(99));
+    }
+
+    @Test
+    @DisplayName("GET /api/frame-collabs/photo-booth/{id} - 매장별 콜라보 목록을 반환한다")
+    void getCollabsByPhotoBooth() throws Exception {
+        given(frameCollabService.getCollabsByPhotoBooth(10L)).willReturn(List.of(summaryDto()));
+
+        mockMvc.perform(get("/api/frame-collabs/photo-booth/10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1));
+    }
+}

--- a/src/test/java/com/min/chalkakserver/service/CollabCandidateServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/CollabCandidateServiceTest.java
@@ -1,0 +1,169 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateApproveRequestDto;
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateRequestDto;
+import com.min.chalkakserver.dto.collabcandidate.CollabCandidateResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabDetailResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabRequestDto;
+import com.min.chalkakserver.entity.CollabCandidate;
+import com.min.chalkakserver.exception.CollabCandidateNotFoundException;
+import com.min.chalkakserver.repository.CollabCandidateRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CollabCandidateService 테스트")
+class CollabCandidateServiceTest {
+
+    @Mock
+    private CollabCandidateRepository collabCandidateRepository;
+    @Mock
+    private FrameCollabService frameCollabService;
+
+    @InjectMocks
+    private CollabCandidateService collabCandidateService;
+
+    private CollabCandidate pendingCandidate() {
+        CollabCandidate candidate = CollabCandidate.builder()
+                .rawText("뉴진스 X 인생네컷\n2026.06.01 ~ 2026.06.30")
+                .title("뉴진스 X 인생네컷")
+                .brand("인생네컷")
+                .artistName("뉴진스")
+                .startDate(LocalDate.of(2026, 6, 1))
+                .endDate(LocalDate.of(2026, 6, 30))
+                .build();
+        ReflectionTestUtils.setField(candidate, "id", 1L);
+        return candidate;
+    }
+
+    @Test
+    @DisplayName("공지 텍스트를 파싱해 후보 초안을 생성한다")
+    void createCandidate_ParsesDraft() {
+        given(collabCandidateRepository.save(any(CollabCandidate.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        CollabCandidateResponseDto result = collabCandidateService.createCandidate(
+                CollabCandidateRequestDto.builder()
+                        .sourceUrl("https://instagram.com/p/abc")
+                        .rawText("뉴진스 X 인생네컷 한정판 프레임\n2026.06.01 ~ 2026.06.30")
+                        .build());
+
+        assertThat(result.getTitle()).isEqualTo("뉴진스 X 인생네컷 한정판 프레임");
+        assertThat(result.getBrand()).isEqualTo("인생네컷");
+        assertThat(result.getArtistName()).isEqualTo("뉴진스");
+        assertThat(result.getStartDate()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(result.getStatus()).isEqualTo(CollabCandidate.CandidateStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("후보를 승인하면 프레임 콜라보가 생성되고 후보가 연결된다")
+    void approveCandidate_CreatesCollab() {
+        CollabCandidate candidate = pendingCandidate();
+        given(collabCandidateRepository.findById(1L)).willReturn(Optional.of(candidate));
+        given(frameCollabService.createCollab(any(FrameCollabRequestDto.class)))
+                .willReturn(FrameCollabDetailResponseDto.builder().id(77L).title("뉴진스 X 인생네컷").build());
+
+        FrameCollabDetailResponseDto result = collabCandidateService.approveCandidate(1L, null);
+
+        assertThat(result.getId()).isEqualTo(77L);
+        assertThat(candidate.getStatus()).isEqualTo(CollabCandidate.CandidateStatus.APPROVED);
+        assertThat(candidate.getCreatedFrameCollabId()).isEqualTo(77L);
+
+        ArgumentCaptor<FrameCollabRequestDto> captor = ArgumentCaptor.forClass(FrameCollabRequestDto.class);
+        verify(frameCollabService).createCollab(captor.capture());
+        assertThat(captor.getValue().getTitle()).isEqualTo("뉴진스 X 인생네컷");
+        assertThat(captor.getValue().getStartDate()).isEqualTo(LocalDate.of(2026, 6, 1));
+    }
+
+    @Test
+    @DisplayName("승인 시 덮어쓰기 필드가 파싱 값보다 우선한다")
+    void approveCandidate_OverridesWin() {
+        CollabCandidate candidate = pendingCandidate();
+        given(collabCandidateRepository.findById(1L)).willReturn(Optional.of(candidate));
+        given(frameCollabService.createCollab(any(FrameCollabRequestDto.class)))
+                .willReturn(FrameCollabDetailResponseDto.builder().id(77L).build());
+
+        collabCandidateService.approveCandidate(1L,
+                CollabCandidateApproveRequestDto.builder()
+                        .title("수정된 콜라보명")
+                        .endDate(LocalDate.of(2026, 7, 15))
+                        .build());
+
+        ArgumentCaptor<FrameCollabRequestDto> captor = ArgumentCaptor.forClass(FrameCollabRequestDto.class);
+        verify(frameCollabService).createCollab(captor.capture());
+        assertThat(captor.getValue().getTitle()).isEqualTo("수정된 콜라보명");
+        assertThat(captor.getValue().getEndDate()).isEqualTo(LocalDate.of(2026, 7, 15));
+        assertThat(captor.getValue().getBrand()).isEqualTo("인생네컷");
+    }
+
+    @Test
+    @DisplayName("필수 필드가 비어 있으면 승인할 수 없다")
+    void approveCandidate_MissingFields() {
+        CollabCandidate incomplete = CollabCandidate.builder()
+                .rawText("기간 미정 공지")
+                .title("기간 미정 공지")
+                .build();
+        ReflectionTestUtils.setField(incomplete, "id", 2L);
+        given(collabCandidateRepository.findById(2L)).willReturn(Optional.of(incomplete));
+
+        assertThatThrownBy(() -> collabCandidateService.approveCandidate(2L, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("제목/시작일/종료일");
+        verify(frameCollabService, never()).createCollab(any());
+    }
+
+    @Test
+    @DisplayName("대기 상태가 아닌 후보는 승인할 수 없다")
+    void approveCandidate_NotPending() {
+        CollabCandidate candidate = pendingCandidate();
+        candidate.reject();
+        given(collabCandidateRepository.findById(1L)).willReturn(Optional.of(candidate));
+
+        assertThatThrownBy(() -> collabCandidateService.approveCandidate(1L, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("대기 중인 후보");
+    }
+
+    @Test
+    @DisplayName("후보를 거절 처리한다")
+    void rejectCandidate() {
+        CollabCandidate candidate = pendingCandidate();
+        given(collabCandidateRepository.findById(1L)).willReturn(Optional.of(candidate));
+
+        CollabCandidateResponseDto result = collabCandidateService.rejectCandidate(1L);
+
+        assertThat(result.getStatus()).isEqualTo(CollabCandidate.CandidateStatus.REJECTED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 후보 승인 시 예외가 발생한다")
+    void approveCandidate_NotFound() {
+        given(collabCandidateRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> collabCandidateService.approveCandidate(99L, null))
+                .isInstanceOf(CollabCandidateNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("잘못된 status 필터는 예외가 발생한다")
+    void getCandidates_InvalidStatus() {
+        assertThatThrownBy(() -> collabCandidateService.getCandidates("unknown", 0, 20))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/min/chalkakserver/service/FrameAvailabilityServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/FrameAvailabilityServiceTest.java
@@ -1,0 +1,245 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityReportRequestDto;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityReportResponseDto;
+import com.min.chalkakserver.dto.frameavailability.FrameAvailabilityResponseDto;
+import com.min.chalkakserver.entity.FrameAvailabilityReport;
+import com.min.chalkakserver.entity.FrameCollab;
+import com.min.chalkakserver.entity.PhotoBooth;
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.exception.DuplicateAvailabilityReportException;
+import com.min.chalkakserver.exception.FrameCollabNotFoundException;
+import com.min.chalkakserver.repository.FrameAvailabilityReportRepository;
+import com.min.chalkakserver.repository.FrameCollabRepository;
+import com.min.chalkakserver.repository.PhotoBoothRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FrameAvailabilityService 테스트")
+class FrameAvailabilityServiceTest {
+
+    @Mock
+    private FrameAvailabilityReportRepository availabilityReportRepository;
+    @Mock
+    private FrameCollabRepository frameCollabRepository;
+    @Mock
+    private PhotoBoothRepository photoBoothRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private FrameAvailabilityService frameAvailabilityService;
+
+    private FrameCollab activeCollab;
+    private PhotoBooth booth;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        activeCollab = FrameCollab.builder()
+                .title("뉴진스 X 인생네컷")
+                .startDate(LocalDate.now().minusDays(3))
+                .endDate(LocalDate.now().plusDays(7))
+                .build();
+        ReflectionTestUtils.setField(activeCollab, "id", 1L);
+
+        booth = PhotoBooth.builder()
+                .name("인생네컷 홍대점")
+                .latitude(37.55)
+                .longitude(126.92)
+                .build();
+        ReflectionTestUtils.setField(booth, "id", 10L);
+
+        user = User.builder()
+                .email("user@test.com")
+                .provider(User.AuthProvider.EMAIL)
+                .providerId("user-1")
+                .role(User.Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 100L);
+    }
+
+    private FrameAvailabilityReport report(FrameAvailabilityReport.AvailabilityStatus status, int minutesAgo) {
+        FrameAvailabilityReport r = FrameAvailabilityReport.builder()
+                .user(user)
+                .frameCollab(activeCollab)
+                .photoBooth(booth)
+                .availabilityStatus(status)
+                .build();
+        ReflectionTestUtils.setField(r, "createdAt", LocalDateTime.now().minusMinutes(minutesAgo));
+        return r;
+    }
+
+    @Test
+    @DisplayName("제보가 없으면 UNKNOWN 상태를 반환한다")
+    void getAvailability_Empty() {
+        given(frameCollabRepository.existsById(1L)).willReturn(true);
+        given(frameCollabRepository.existsByIdAndPhotoBoothsId(1L, 10L)).willReturn(true);
+        given(availabilityReportRepository
+                .findByFrameCollabIdAndPhotoBoothIdAndCreatedAtAfterOrderByCreatedAtDesc(any(), any(), any()))
+                .willReturn(List.of());
+
+        FrameAvailabilityResponseDto result = frameAvailabilityService.getAvailability(1L, 10L);
+
+        assertThat(result.getStatus()).isEqualTo(FrameAvailabilityResponseDto.ResultStatus.UNKNOWN);
+        assertThat(result.getSampleSize()).isZero();
+    }
+
+    @Test
+    @DisplayName("최근 품절 제보가 오래된 있음 제보보다 큰 가중치를 가진다")
+    void getAvailability_RecentSoldOutWins() {
+        given(frameCollabRepository.existsById(1L)).willReturn(true);
+        given(frameCollabRepository.existsByIdAndPhotoBoothsId(1L, 10L)).willReturn(true);
+        given(availabilityReportRepository
+                .findByFrameCollabIdAndPhotoBoothIdAndCreatedAtAfterOrderByCreatedAtDesc(any(), any(), any()))
+                .willReturn(List.of(
+                        report(FrameAvailabilityReport.AvailabilityStatus.SOLD_OUT, 10),
+                        report(FrameAvailabilityReport.AvailabilityStatus.SOLD_OUT, 30),
+                        report(FrameAvailabilityReport.AvailabilityStatus.AVAILABLE, 1200)
+                ));
+
+        FrameAvailabilityResponseDto result = frameAvailabilityService.getAvailability(1L, 10L);
+
+        assertThat(result.getStatus()).isEqualTo(FrameAvailabilityResponseDto.ResultStatus.SOLD_OUT);
+        assertThat(result.getSampleSize()).isEqualTo(3);
+        assertThat(result.getConfidenceLevel()).isEqualTo(FrameAvailabilityResponseDto.ConfidenceLevel.MEDIUM);
+    }
+
+    @Test
+    @DisplayName("콜라보 입고 매장이 아니면 예외가 발생한다")
+    void getAvailability_NotCollabBooth() {
+        given(frameCollabRepository.existsById(1L)).willReturn(true);
+        given(frameCollabRepository.existsByIdAndPhotoBoothsId(1L, 99L)).willReturn(false);
+
+        assertThatThrownBy(() -> frameAvailabilityService.getAvailability(1L, 99L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("입고 매장이 아닙니다");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콜라보 조회 시 예외가 발생한다")
+    void getAvailability_CollabNotFound() {
+        given(frameCollabRepository.existsById(99L)).willReturn(false);
+
+        assertThatThrownBy(() -> frameAvailabilityService.getAvailability(99L, 10L))
+                .isInstanceOf(FrameCollabNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("콜라보 전체 매장 조회 시 제보 없는 매장은 UNKNOWN으로 반환한다")
+    void getCollabAvailability_MixesUnknown() {
+        PhotoBooth booth2 = PhotoBooth.builder()
+                .name("인생네컷 강남점")
+                .latitude(37.49)
+                .longitude(127.02)
+                .build();
+        ReflectionTestUtils.setField(booth2, "id", 20L);
+        activeCollab.updatePhotoBooths(Set.of(booth, booth2));
+
+        given(frameCollabRepository.findByIdWithBooths(1L)).willReturn(Optional.of(activeCollab));
+        given(availabilityReportRepository
+                .findByFrameCollabIdAndCreatedAtAfterOrderByCreatedAtDesc(any(), any()))
+                .willReturn(List.of(report(FrameAvailabilityReport.AvailabilityStatus.AVAILABLE, 5)));
+
+        List<FrameAvailabilityResponseDto> result = frameAvailabilityService.getCollabAvailability(1L);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getPhotoBoothId()).isEqualTo(10L);
+        assertThat(result.get(0).getStatus()).isEqualTo(FrameAvailabilityResponseDto.ResultStatus.AVAILABLE);
+        assertThat(result.get(1).getPhotoBoothId()).isEqualTo(20L);
+        assertThat(result.get(1).getStatus()).isEqualTo(FrameAvailabilityResponseDto.ResultStatus.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("재고를 제보하면 저장되고 응답을 반환한다")
+    void submitReport_Success() {
+        given(userRepository.findById(100L)).willReturn(Optional.of(user));
+        given(frameCollabRepository.findById(1L)).willReturn(Optional.of(activeCollab));
+        given(photoBoothRepository.findById(10L)).willReturn(Optional.of(booth));
+        given(frameCollabRepository.existsById(1L)).willReturn(true);
+        given(frameCollabRepository.existsByIdAndPhotoBoothsId(1L, 10L)).willReturn(true);
+        given(availabilityReportRepository
+                .existsByUserAndFrameCollabAndPhotoBoothAndCreatedAtAfter(any(), any(), any(), any()))
+                .willReturn(false);
+        given(availabilityReportRepository.save(any(FrameAvailabilityReport.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        FrameAvailabilityReportResponseDto result = frameAvailabilityService.submitReport(
+                100L, 1L, 10L,
+                FrameAvailabilityReportRequestDto.builder()
+                        .availabilityStatus(FrameAvailabilityReport.AvailabilityStatus.SOLD_OUT)
+                        .build());
+
+        assertThat(result.getFrameCollabId()).isEqualTo(1L);
+        assertThat(result.getPhotoBoothId()).isEqualTo(10L);
+        verify(availabilityReportRepository).save(any(FrameAvailabilityReport.class));
+    }
+
+    @Test
+    @DisplayName("쿨다운 내 중복 제보 시 예외가 발생한다")
+    void submitReport_Cooldown() {
+        given(userRepository.findById(100L)).willReturn(Optional.of(user));
+        given(frameCollabRepository.findById(1L)).willReturn(Optional.of(activeCollab));
+        given(photoBoothRepository.findById(10L)).willReturn(Optional.of(booth));
+        given(frameCollabRepository.existsById(1L)).willReturn(true);
+        given(frameCollabRepository.existsByIdAndPhotoBoothsId(1L, 10L)).willReturn(true);
+        given(availabilityReportRepository
+                .existsByUserAndFrameCollabAndPhotoBoothAndCreatedAtAfter(any(), any(), any(), any()))
+                .willReturn(true);
+
+        assertThatThrownBy(() -> frameAvailabilityService.submitReport(
+                100L, 1L, 10L,
+                FrameAvailabilityReportRequestDto.builder()
+                        .availabilityStatus(FrameAvailabilityReport.AvailabilityStatus.AVAILABLE)
+                        .build()))
+                .isInstanceOf(DuplicateAvailabilityReportException.class);
+        verify(availabilityReportRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("진행 중이 아닌 콜라보에는 제보할 수 없다")
+    void submitReport_NotActiveCollab() {
+        FrameCollab endedCollab = FrameCollab.builder()
+                .title("종료된 콜라보")
+                .startDate(LocalDate.now().minusDays(30))
+                .endDate(LocalDate.now().minusDays(1))
+                .build();
+        ReflectionTestUtils.setField(endedCollab, "id", 2L);
+
+        given(userRepository.findById(100L)).willReturn(Optional.of(user));
+        given(frameCollabRepository.findById(2L)).willReturn(Optional.of(endedCollab));
+        given(photoBoothRepository.findById(10L)).willReturn(Optional.of(booth));
+        given(frameCollabRepository.existsById(2L)).willReturn(true);
+        given(frameCollabRepository.existsByIdAndPhotoBoothsId(2L, 10L)).willReturn(true);
+
+        assertThatThrownBy(() -> frameAvailabilityService.submitReport(
+                100L, 2L, 10L,
+                FrameAvailabilityReportRequestDto.builder()
+                        .availabilityStatus(FrameAvailabilityReport.AvailabilityStatus.AVAILABLE)
+                        .build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("진행 중인 콜라보");
+        verify(availabilityReportRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/min/chalkakserver/service/FrameCollabServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/FrameCollabServiceTest.java
@@ -1,0 +1,232 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabDetailResponseDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabRequestDto;
+import com.min.chalkakserver.dto.framecollab.FrameCollabResponseDto;
+import com.min.chalkakserver.entity.FrameCollab;
+import com.min.chalkakserver.entity.PhotoBooth;
+import com.min.chalkakserver.exception.FrameCollabNotFoundException;
+import com.min.chalkakserver.exception.PhotoBoothNotFoundException;
+import com.min.chalkakserver.repository.FrameCollabRepository;
+import com.min.chalkakserver.repository.PhotoBoothRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FrameCollabService 테스트")
+class FrameCollabServiceTest {
+
+    @Mock
+    private FrameCollabRepository frameCollabRepository;
+    @Mock
+    private PhotoBoothRepository photoBoothRepository;
+
+    @InjectMocks
+    private FrameCollabService frameCollabService;
+
+    private FrameCollab activeCollab;
+    private PhotoBooth booth;
+
+    @BeforeEach
+    void setUp() {
+        activeCollab = FrameCollab.builder()
+                .title("뉴진스 X 인생네컷")
+                .brand("인생네컷")
+                .artistName("뉴진스")
+                .startDate(LocalDate.now().minusDays(3))
+                .endDate(LocalDate.now().plusDays(7))
+                .build();
+        ReflectionTestUtils.setField(activeCollab, "id", 1L);
+
+        booth = PhotoBooth.builder()
+                .name("인생네컷 홍대점")
+                .brand("인생네컷")
+                .latitude(37.55)
+                .longitude(126.92)
+                .build();
+        ReflectionTestUtils.setField(booth, "id", 10L);
+    }
+
+    @Test
+    @DisplayName("진행 중 콜라보 목록을 페이지로 반환한다")
+    void getCollabs_Active() {
+        given(frameCollabRepository.findActive(any(LocalDate.class), any()))
+                .willReturn(new PageImpl<>(List.of(activeCollab), PageRequest.of(0, 20), 1));
+
+        PagedResponseDto<FrameCollabResponseDto> result = frameCollabService.getCollabs("active", 0, 20);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("뉴진스 X 인생네컷");
+        assertThat(result.getContent().get(0).getStatus()).isEqualTo(FrameCollab.CollabStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("예정 콜라보 조회 시 upcoming 쿼리를 사용한다")
+    void getCollabs_Upcoming() {
+        given(frameCollabRepository.findUpcoming(any(LocalDate.class), any()))
+                .willReturn(new PageImpl<>(List.of()));
+
+        frameCollabService.getCollabs("upcoming", 0, 20);
+
+        verify(frameCollabRepository).findUpcoming(any(LocalDate.class), any());
+        verify(frameCollabRepository, never()).findActive(any(LocalDate.class), any());
+    }
+
+    @Test
+    @DisplayName("콜라보 상세 조회 시 입고 매장 목록을 포함한다")
+    void getCollab_WithBooths() {
+        activeCollab.updatePhotoBooths(java.util.Set.of(booth));
+        given(frameCollabRepository.findByIdWithBooths(1L)).willReturn(Optional.of(activeCollab));
+
+        FrameCollabDetailResponseDto result = frameCollabService.getCollab(1L);
+
+        assertThat(result.getPhotoBooths()).hasSize(1);
+        assertThat(result.getPhotoBooths().get(0).getName()).isEqualTo("인생네컷 홍대점");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콜라보 조회 시 예외가 발생한다")
+    void getCollab_NotFound() {
+        given(frameCollabRepository.findByIdWithBooths(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> frameCollabService.getCollab(99L))
+                .isInstanceOf(FrameCollabNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 매장의 콜라보 조회 시 예외가 발생한다")
+    void getCollabsByPhotoBooth_BoothNotFound() {
+        given(photoBoothRepository.existsById(99L)).willReturn(false);
+
+        assertThatThrownBy(() -> frameCollabService.getCollabsByPhotoBooth(99L))
+                .isInstanceOf(PhotoBoothNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("매장별 진행/예정 콜라보 목록을 반환한다")
+    void getCollabsByPhotoBooth_Success() {
+        given(photoBoothRepository.existsById(10L)).willReturn(true);
+        given(frameCollabRepository.findCurrentByPhotoBoothId(any(), any(LocalDate.class)))
+                .willReturn(List.of(activeCollab));
+
+        List<FrameCollabResponseDto> result = frameCollabService.getCollabsByPhotoBooth(10L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("입고 매장과 함께 콜라보를 생성한다")
+    void createCollab_WithBooths() {
+        FrameCollabRequestDto request = FrameCollabRequestDto.builder()
+                .title("에스파 X 포토이즘")
+                .brand("포토이즘")
+                .artistName("에스파")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(14))
+                .photoBoothIds(List.of(10L))
+                .build();
+        given(photoBoothRepository.findAllById(List.of(10L))).willReturn(List.of(booth));
+        given(frameCollabRepository.save(any(FrameCollab.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        FrameCollabDetailResponseDto result = frameCollabService.createCollab(request);
+
+        assertThat(result.getTitle()).isEqualTo("에스파 X 포토이즘");
+        assertThat(result.getPhotoBooths()).hasSize(1);
+        verify(frameCollabRepository).save(any(FrameCollab.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 매장 ID로 생성 시 예외가 발생한다")
+    void createCollab_MissingBooth() {
+        FrameCollabRequestDto request = FrameCollabRequestDto.builder()
+                .title("에스파 X 포토이즘")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(14))
+                .photoBoothIds(List.of(10L, 99L))
+                .build();
+        given(photoBoothRepository.findAllById(List.of(10L, 99L))).willReturn(List.of(booth));
+
+        assertThatThrownBy(() -> frameCollabService.createCollab(request))
+                .isInstanceOf(PhotoBoothNotFoundException.class)
+                .hasMessageContaining("99");
+        verify(frameCollabRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("콜라보 정보를 수정한다")
+    void updateCollab_Success() {
+        given(frameCollabRepository.findByIdWithBooths(1L)).willReturn(Optional.of(activeCollab));
+        FrameCollabRequestDto request = FrameCollabRequestDto.builder()
+                .title("수정된 제목")
+                .brand("인생네컷")
+                .artistName("뉴진스")
+                .startDate(LocalDate.now().minusDays(3))
+                .endDate(LocalDate.now().plusDays(10))
+                .build();
+
+        FrameCollabDetailResponseDto result = frameCollabService.updateCollab(1L, request);
+
+        assertThat(result.getTitle()).isEqualTo("수정된 제목");
+        assertThat(result.getEndDate()).isEqualTo(LocalDate.now().plusDays(10));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콜라보 삭제 시 예외가 발생한다")
+    void deleteCollab_NotFound() {
+        given(frameCollabRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> frameCollabService.deleteCollab(99L))
+                .isInstanceOf(FrameCollabNotFoundException.class);
+        verify(frameCollabRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("입고 매장을 일괄 설정한다")
+    void setPhotoBooths_Success() {
+        given(frameCollabRepository.findByIdWithBooths(1L)).willReturn(Optional.of(activeCollab));
+        given(photoBoothRepository.findAllById(List.of(10L))).willReturn(List.of(booth));
+
+        FrameCollabDetailResponseDto result = frameCollabService.setPhotoBooths(1L, List.of(10L));
+
+        assertThat(result.getPhotoBooths()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("날짜 기준으로 콜라보 상태를 판별한다")
+    void getStatus_ByDate() {
+        LocalDate today = LocalDate.of(2026, 6, 12);
+        FrameCollab collab = FrameCollab.builder()
+                .title("t")
+                .startDate(LocalDate.of(2026, 6, 10))
+                .endDate(LocalDate.of(2026, 6, 20))
+                .build();
+
+        assertThat(collab.getStatus(today)).isEqualTo(FrameCollab.CollabStatus.ACTIVE);
+        assertThat(collab.getStatus(LocalDate.of(2026, 6, 9))).isEqualTo(FrameCollab.CollabStatus.UPCOMING);
+        assertThat(collab.getStatus(LocalDate.of(2026, 6, 21))).isEqualTo(FrameCollab.CollabStatus.ENDED);
+        assertThat(collab.getStatus(LocalDate.of(2026, 6, 10))).isEqualTo(FrameCollab.CollabStatus.ACTIVE);
+        assertThat(collab.getStatus(LocalDate.of(2026, 6, 20))).isEqualTo(FrameCollab.CollabStatus.ACTIVE);
+    }
+}

--- a/src/test/java/com/min/chalkakserver/service/PhotobookServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/PhotobookServiceTest.java
@@ -1,0 +1,226 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.photobook.PhotobookCollectionResponseDto;
+import com.min.chalkakserver.dto.photobook.PhotobookEntryRequestDto;
+import com.min.chalkakserver.dto.photobook.PhotobookEntryResponseDto;
+import com.min.chalkakserver.entity.FrameCollab;
+import com.min.chalkakserver.entity.PhotobookEntry;
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.exception.FrameCollabNotFoundException;
+import com.min.chalkakserver.exception.PhotobookEntryNotFoundException;
+import com.min.chalkakserver.repository.FrameCollabRepository;
+import com.min.chalkakserver.repository.PhotoBoothRepository;
+import com.min.chalkakserver.repository.PhotobookEntryRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PhotobookService 테스트")
+class PhotobookServiceTest {
+
+    @Mock
+    private PhotobookEntryRepository photobookEntryRepository;
+    @Mock
+    private FrameCollabRepository frameCollabRepository;
+    @Mock
+    private PhotoBoothRepository photoBoothRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PhotobookService photobookService;
+
+    private User user;
+    private User otherUser;
+    private FrameCollab collab;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .email("user@test.com")
+                .provider(User.AuthProvider.EMAIL)
+                .providerId("user-1")
+                .role(User.Role.USER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 100L);
+
+        otherUser = User.builder()
+                .email("other@test.com")
+                .provider(User.AuthProvider.EMAIL)
+                .providerId("user-2")
+                .role(User.Role.USER)
+                .build();
+        ReflectionTestUtils.setField(otherUser, "id", 200L);
+
+        collab = FrameCollab.builder()
+                .title("뉴진스 X 인생네컷")
+                .artistName("뉴진스")
+                .startDate(LocalDate.now().minusDays(3))
+                .endDate(LocalDate.now().plusDays(7))
+                .build();
+        ReflectionTestUtils.setField(collab, "id", 1L);
+    }
+
+    private PhotobookEntry entry(User owner) {
+        PhotobookEntry e = PhotobookEntry.builder()
+                .user(owner)
+                .frameCollab(collab)
+                .imageUrl("https://cdn.test/photo.jpg")
+                .build();
+        ReflectionTestUtils.setField(e, "id", 10L);
+        return e;
+    }
+
+    @Test
+    @DisplayName("콜라보 태깅과 함께 포토북 사진을 등록한다")
+    void createEntry_WithCollab() {
+        given(userRepository.findById(100L)).willReturn(Optional.of(user));
+        given(frameCollabRepository.findById(1L)).willReturn(Optional.of(collab));
+        given(photobookEntryRepository.save(any(PhotobookEntry.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        PhotobookEntryResponseDto result = photobookService.createEntry(100L,
+                PhotobookEntryRequestDto.builder()
+                        .imageUrl("https://cdn.test/photo.jpg")
+                        .frameCollabId(1L)
+                        .build());
+
+        assertThat(result.getImageUrl()).isEqualTo("https://cdn.test/photo.jpg");
+        assertThat(result.getFrameCollabId()).isEqualTo(1L);
+        assertThat(result.getFrameCollabTitle()).isEqualTo("뉴진스 X 인생네컷");
+        verify(photobookEntryRepository).save(any(PhotobookEntry.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콜라보 태깅 시 예외가 발생한다")
+    void createEntry_CollabNotFound() {
+        given(userRepository.findById(100L)).willReturn(Optional.of(user));
+        given(frameCollabRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> photobookService.createEntry(100L,
+                PhotobookEntryRequestDto.builder()
+                        .imageUrl("https://cdn.test/photo.jpg")
+                        .frameCollabId(99L)
+                        .build()))
+                .isInstanceOf(FrameCollabNotFoundException.class);
+        verify(photobookEntryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("태깅 없이도 사진을 등록할 수 있다")
+    void createEntry_WithoutTags() {
+        given(userRepository.findById(100L)).willReturn(Optional.of(user));
+        given(photobookEntryRepository.save(any(PhotobookEntry.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        PhotobookEntryResponseDto result = photobookService.createEntry(100L,
+                PhotobookEntryRequestDto.builder()
+                        .imageUrl("https://cdn.test/photo.jpg")
+                        .build());
+
+        assertThat(result.getFrameCollabId()).isNull();
+        assertThat(result.getPhotoBoothId()).isNull();
+    }
+
+    @Test
+    @DisplayName("내 포토북을 최신순 페이지로 조회한다")
+    void getMyEntries() {
+        given(photobookEntryRepository.findByUserIdOrderByCreatedAtDesc(any(), any()))
+                .willReturn(new PageImpl<>(List.of(entry(user)), PageRequest.of(0, 20), 1));
+
+        PagedResponseDto<PhotobookEntryResponseDto> result = photobookService.getMyEntries(100L, 0, 20);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("본인 소유가 아닌 사진 삭제 시 예외가 발생한다")
+    void deleteEntry_NotOwner() {
+        given(photobookEntryRepository.findById(10L)).willReturn(Optional.of(entry(otherUser)));
+
+        assertThatThrownBy(() -> photobookService.deleteEntry(100L, 10L))
+                .isInstanceOf(AuthException.class);
+        verify(photobookEntryRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사진 삭제 시 예외가 발생한다")
+    void deleteEntry_NotFound() {
+        given(photobookEntryRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> photobookService.deleteEntry(100L, 99L))
+                .isInstanceOf(PhotobookEntryNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 사진은 삭제된다")
+    void deleteEntry_Success() {
+        PhotobookEntry owned = entry(user);
+        given(photobookEntryRepository.findById(10L)).willReturn(Optional.of(owned));
+
+        photobookService.deleteEntry(100L, 10L);
+
+        verify(photobookEntryRepository).delete(owned);
+    }
+
+    @Test
+    @DisplayName("도감은 콜라보별 사진 수와 수집 여부를 집계한다")
+    void getMyCollection() {
+        FrameCollab uncollected = FrameCollab.builder()
+                .title("에스파 X 포토이즘")
+                .startDate(LocalDate.now().minusDays(10))
+                .endDate(LocalDate.now().minusDays(2))
+                .build();
+        ReflectionTestUtils.setField(uncollected, "id", 2L);
+
+        PhotobookEntryRepository.CollabPhotoCount count = new PhotobookEntryRepository.CollabPhotoCount() {
+            @Override
+            public Long getCollabId() {
+                return 1L;
+            }
+
+            @Override
+            public Long getPhotoCount() {
+                return 3L;
+            }
+        };
+
+        given(photobookEntryRepository.countByUserGroupedByCollab(100L)).willReturn(List.of(count));
+        given(frameCollabRepository.findAll(any(Sort.class))).willReturn(List.of(collab, uncollected));
+        given(photobookEntryRepository.countByUserId(100L)).willReturn(4L);
+
+        PhotobookCollectionResponseDto result = photobookService.getMyCollection(100L);
+
+        assertThat(result.getTotalCollabs()).isEqualTo(2);
+        assertThat(result.getCollectedCollabs()).isEqualTo(1);
+        assertThat(result.getTotalPhotos()).isEqualTo(4L);
+        assertThat(result.getItems().get(0).isCollected()).isTrue();
+        assertThat(result.getItems().get(0).getPhotoCount()).isEqualTo(3L);
+        assertThat(result.getItems().get(1).isCollected()).isFalse();
+        assertThat(result.getItems().get(1).getPhotoCount()).isZero();
+    }
+}

--- a/src/test/java/com/min/chalkakserver/util/CollabTextParserTest.java
+++ b/src/test/java/com/min/chalkakserver/util/CollabTextParserTest.java
@@ -1,0 +1,90 @@
+package com.min.chalkakserver.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CollabTextParser 테스트")
+class CollabTextParserTest {
+
+    private static final LocalDate REFERENCE = LocalDate.of(2026, 6, 12);
+
+    @Test
+    @DisplayName("연도 포함 기간과 브랜드, 아티스트를 추출한다")
+    void parse_FullDates() {
+        String text = """
+                뉴진스 X 인생네컷 한정판 프레임 출시!
+                기간: 2026.06.01 ~ 2026.06.30
+                전국 매장에서 만나보세요.
+                """;
+
+        CollabTextParser.ParsedCollab result = CollabTextParser.parse(text, REFERENCE);
+
+        assertThat(result.title()).isEqualTo("뉴진스 X 인생네컷 한정판 프레임 출시!");
+        assertThat(result.brand()).isEqualTo("인생네컷");
+        assertThat(result.artistName()).isEqualTo("뉴진스");
+        assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 6, 30));
+    }
+
+    @Test
+    @DisplayName("한국어 날짜 표기를 파싱한다")
+    void parse_KoreanDates() {
+        String text = "에스파 × 포토이즘 콜라보\n2026년 7월 1일부터 2026년 7월 15일까지";
+
+        CollabTextParser.ParsedCollab result = CollabTextParser.parse(text, REFERENCE);
+
+        assertThat(result.brand()).isEqualTo("포토이즘");
+        assertThat(result.artistName()).isEqualTo("에스파");
+        assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 7, 1));
+        assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 7, 15));
+    }
+
+    @Test
+    @DisplayName("연도 생략 날짜는 기준 연도로 채운다")
+    void parse_ShortDates() {
+        String text = "하루필름 신규 프레임\n6월 20일 ~ 7월 10일";
+
+        CollabTextParser.ParsedCollab result = CollabTextParser.parse(text, REFERENCE);
+
+        assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 6, 20));
+        assertThat(result.endDate()).isEqualTo(LocalDate.of(2026, 7, 10));
+    }
+
+    @Test
+    @DisplayName("연말에 걸친 기간은 종료일을 이듬해로 보정한다")
+    void parse_YearRollover() {
+        String text = "포토그레이 윈터 에디션\n12월 20일 ~ 1월 5일";
+
+        CollabTextParser.ParsedCollab result = CollabTextParser.parse(text, REFERENCE);
+
+        assertThat(result.startDate()).isEqualTo(LocalDate.of(2026, 12, 20));
+        assertThat(result.endDate()).isEqualTo(LocalDate.of(2027, 1, 5));
+    }
+
+    @Test
+    @DisplayName("브랜드와 날짜가 없으면 제목만 추출한다")
+    void parse_TitleOnly() {
+        String text = "신규 콜라보 공지 예정";
+
+        CollabTextParser.ParsedCollab result = CollabTextParser.parse(text, REFERENCE);
+
+        assertThat(result.title()).isEqualTo("신규 콜라보 공지 예정");
+        assertThat(result.brand()).isNull();
+        assertThat(result.artistName()).isNull();
+        assertThat(result.startDate()).isNull();
+        assertThat(result.endDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("빈 텍스트는 모든 필드가 null이다")
+    void parse_Empty() {
+        CollabTextParser.ParsedCollab result = CollabTextParser.parse("  \n ", REFERENCE);
+
+        assertThat(result.title()).isNull();
+        assertThat(result.brand()).isNull();
+    }
+}


### PR DESCRIPTION
## 개요
네컷사진관 지도 서비스를 '한정판 프레임 콜라보 + 포토북 아카이빙' 방향으로 확장하는 서버 기능입니다.

## 변경사항
- **콜라보 API**: FrameCollab 엔티티(PhotoBooth N:M), 피드(진행중/예정/종료)·상세·매장별 조회, 어드민 CRUD + 입고 매장 설정
- **재고 제보 API**: FrameAvailabilityReport, 24h 윈도우 시간가중 집계(6h 감쇠)+60분 쿨다운+신뢰도, 매장별/콜라보 전체 조회, 제보(인증)
- **디지털 포토북/도감 API**: PhotobookEntry(콜라보/매장 태깅), 등록·조회·삭제, 콜라보별 수집 현황 집계. 기존 S3 업로드 재사용
- **콜라보 후보 큐**: 공지 텍스트 붙여넣기 → 휴리스틱 파싱(제목/브랜드/아티스트/기간) → 어드민 검토·승인 시 콜라보 자동 등록
- **성능**: 콜라보 피드 매장 수 조회 N+1을 @BatchSize로 완화

## 테스트
- `./gradlew test` 전체 통과 (신규: FrameCollab/FrameAvailability/Photobook/CollabCandidate/CollabTextParser 서비스·컨트롤러 테스트)

## ⚠️ 배포 주의
- 새 테이블 6개 생성됨(frame_collabs, frame_collab_booths, frame_availability_reports, photobook_entries, collab_candidates). 프로덕션은 `ddl-auto: validate`이므로 **이번 릴리스는 `DDL_AUTO=update`로 1회 기동 후 `validate` 복귀** 필요
- 포토북 업로드는 기존 S3 설정(`cloud.aws.s3.bucket`) 사용
- 재고 제보 UI는 앱에서 피처 플래그로 비노출 상태 (API는 활성)