### PR TITLE
feat: 네컷 사진첩 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     // AWS S3
     implementation 'software.amazon.awssdk:s3:2.25.27'
 
+    // Thumbnail 생성
+    implementation 'net.coobird:thumbnailator:0.4.20'
+
     // Firebase Admin SDK
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,73 @@ services:
     networks:
       - chalkak-network
 
+  # ── 로컬 개발용 MySQL ──────────────────────────────────────────────
+  # application.yml 기본값과 일치: chalkak_db / chalkak / chalkak123
+  mysql:
+    image: mysql:8.0
+    container_name: chalkak-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: chalkak_db
+      MYSQL_USER: chalkak
+      MYSQL_PASSWORD: chalkak123
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uchalkak", "-pchalkak123"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - chalkak-network
+
+  # ── 로컬 개발용 MinIO (S3 호환 오브젝트 스토리지) ─────────────────
+  # API :9000 / 콘솔 :9001 (minioadmin / minioadmin)
+  minio:
+    image: minio/minio:latest
+    container_name: chalkak-minio
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - chalkak-network
+
+  # 버킷 자동 생성 + 익명 read 허용 (앱이 반환하는 public 이미지 URL 로딩용)
+  createbuckets:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set local http://minio:9000 minioadmin minioadmin;
+      /usr/bin/mc mb -p local/chalkak-uploads;
+      /usr/bin/mc anonymous set download local/chalkak-uploads;
+      exit 0;
+      "
+    networks:
+      - chalkak-network
+
 volumes:
   redis_data:
+    driver: local
+  mysql_data:
+    driver: local
+  minio_data:
     driver: local
 
 networks:

--- a/src/main/java/com/min/chalkakserver/config/S3Config.java
+++ b/src/main/java/com/min/chalkakserver/config/S3Config.java
@@ -7,6 +7,10 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
 
 @Configuration
 public class S3Config {
@@ -20,12 +24,26 @@ public class S3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    // 로컬 MinIO 등 S3 호환 스토리지용 커스텀 엔드포인트. 비어있으면 실제 AWS S3 사용.
+    @Value("${cloud.aws.s3.endpoint:}")
+    private String endpoint;
+
     @Bean
     public S3Client s3Client() {
-        return S3Client.builder()
+        S3ClientBuilder builder = S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
-                .build();
+                        AwsBasicCredentials.create(accessKey, secretKey)));
+
+        // 엔드포인트가 지정된 경우(MinIO 등)만 오버라이드 + path-style 접근.
+        if (endpoint != null && !endpoint.isBlank()) {
+            builder = builder
+                    .endpointOverride(URI.create(endpoint))
+                    .serviceConfiguration(S3Configuration.builder()
+                            .pathStyleAccessEnabled(true)
+                            .build());
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/com/min/chalkakserver/controller/PhotoAlbumController.java
+++ b/src/main/java/com/min/chalkakserver/controller/PhotoAlbumController.java
@@ -1,0 +1,104 @@
+package com.min.chalkakserver.controller;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.album.PhotoBulkDeleteRequestDto;
+import com.min.chalkakserver.dto.album.PhotoResponseDto;
+import com.min.chalkakserver.dto.album.PhotoUpdateRequestDto;
+import com.min.chalkakserver.security.CustomUserDetails;
+import com.min.chalkakserver.service.PhotoAlbumService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+@Tag(name = "Photo Album", description = "네컷 사진첩 API")
+@RestController
+@RequestMapping("/api/album/photos")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+@Slf4j
+public class PhotoAlbumController {
+
+    private final PhotoAlbumService photoAlbumService;
+
+    @Operation(summary = "사진 업로드", description = "네컷 이미지 파일 업로드 (로그인 필요)")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PhotoResponseDto> uploadPhoto(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "memo", required = false) String memo,
+            @RequestParam(value = "photoDate", required = false) String photoDate) throws IOException {
+        LocalDateTime parsedPhotoDate = null;
+        if (photoDate != null && !photoDate.isBlank()) {
+            try {
+                parsedPhotoDate = LocalDateTime.parse(photoDate);
+            } catch (DateTimeParseException e) {
+                log.warn("Invalid photoDate ignored: value={}, reason={}", photoDate, e.getMessage());
+            }
+        }
+        PhotoResponseDto response = photoAlbumService.uploadPhoto(userDetails.getId(), file, memo, parsedPhotoDate);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "내 사진 목록", description = "내 사진첩 목록 조회 (createdAt DESC), favorite=true 시 찜만 (로그인 필요)")
+    @GetMapping
+    public ResponseEntity<List<PhotoResponseDto>> getMyPhotos(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(value = "favorite", defaultValue = "false") boolean favorite) {
+        List<PhotoResponseDto> response = photoAlbumService.getMyPhotos(userDetails.getId(), favorite);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 사진 목록 (페이징)", description = "내 사진첩 목록 페이징 조회 (로그인 필요)")
+    @GetMapping("/paged")
+    public ResponseEntity<PagedResponseDto<PhotoResponseDto>> getMyPhotosPaged(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(value = "favorite", defaultValue = "false") boolean favorite) {
+        PagedResponseDto<PhotoResponseDto> response =
+            photoAlbumService.getMyPhotosPaged(userDetails.getId(), favorite, page, size);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "사진 수정", description = "메모/찜 부분 수정 (로그인 필요)")
+    @PatchMapping("/{id}")
+    public ResponseEntity<PhotoResponseDto> updatePhoto(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id,
+            @Valid @RequestBody PhotoUpdateRequestDto request) {
+        PhotoResponseDto response = photoAlbumService.updatePhoto(userDetails.getId(), id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "사진 삭제", description = "내 사진 단건 삭제 (S3 객체 포함, 로그인 필요)")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePhoto(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id) {
+        photoAlbumService.deletePhoto(userDetails.getId(), id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "사진 다중 삭제", description = "선택한 사진 벌크 삭제 (본인 소유만, 로그인 필요)")
+    @DeleteMapping
+    public ResponseEntity<Void> deletePhotos(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PhotoBulkDeleteRequestDto request) {
+        photoAlbumService.deletePhotos(userDetails.getId(), request.getIds());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/album/PhotoBulkDeleteRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/album/PhotoBulkDeleteRequestDto.java
@@ -1,0 +1,19 @@
+package com.min.chalkakserver.dto.album;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoBulkDeleteRequestDto {
+
+    @NotEmpty(message = "삭제할 사진 ID 목록이 비어있습니다.")
+    private List<Long> ids;
+}

--- a/src/main/java/com/min/chalkakserver/dto/album/PhotoResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/album/PhotoResponseDto.java
@@ -1,0 +1,37 @@
+package com.min.chalkakserver.dto.album;
+
+import com.min.chalkakserver.entity.Photo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoResponseDto {
+    private Long id;
+    private String imageUrl;
+    private String thumbnailUrl;
+    private String memo;
+    private boolean favorite;
+    private Photo.PhotoSource source;
+    private LocalDateTime photoDate;
+    private LocalDateTime createdAt;
+
+    public static PhotoResponseDto from(Photo photo) {
+        return PhotoResponseDto.builder()
+            .id(photo.getId())
+            .imageUrl(photo.getImageUrl())
+            .thumbnailUrl(photo.getThumbnailUrl())
+            .memo(photo.getMemo())
+            .favorite(photo.isFavorite())
+            .source(photo.getSource())
+            .photoDate(photo.getPhotoDate())
+            .createdAt(photo.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/album/PhotoUpdateRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/album/PhotoUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.min.chalkakserver.dto.album;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoUpdateRequestDto {
+
+    @Size(max = 50, message = "메모는 50자를 초과할 수 없습니다.")
+    private String memo;
+
+    private Boolean favorite;
+}

--- a/src/main/java/com/min/chalkakserver/entity/Photo.java
+++ b/src/main/java/com/min/chalkakserver/entity/Photo.java
@@ -1,0 +1,89 @@
+package com.min.chalkakserver.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "photos",
+    indexes = {
+        @Index(name = "idx_photo_user_created", columnList = "user_id, created_at")
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Photo {
+
+    public enum PhotoSource {
+        FILE_UPLOAD, QR_DOWNLOAD
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
+    @Column(length = 50)
+    private String memo;
+
+    @Column(name = "is_favorite")
+    private boolean favorite;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private PhotoSource source;
+
+    @Column(name = "photo_date")
+    private LocalDateTime photoDate;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+        if (photoDate == null) {
+            photoDate = createdAt;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Photo(User user, String imageUrl, String thumbnailUrl, String memo, boolean favorite, PhotoSource source, LocalDateTime photoDate) {
+        this.user = user;
+        this.imageUrl = imageUrl;
+        this.thumbnailUrl = thumbnailUrl;
+        this.memo = memo;
+        this.favorite = favorite;
+        this.source = source;
+        this.photoDate = photoDate;
+    }
+
+    public void updateMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public void updateFavorite(boolean favorite) {
+        this.favorite = favorite;
+    }
+}

--- a/src/main/java/com/min/chalkakserver/repository/PhotoRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/PhotoRepository.java
@@ -1,0 +1,26 @@
+package com.min.chalkakserver.repository;
+
+import com.min.chalkakserver.entity.Photo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+
+    List<Photo> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    List<Photo> findByUserIdAndFavoriteTrueOrderByCreatedAtDesc(Long userId);
+
+    Page<Photo> findByUserId(Long userId, Pageable pageable);
+
+    Page<Photo> findByUserIdAndFavoriteTrue(Long userId, Pageable pageable);
+
+    Optional<Photo> findByIdAndUserId(Long id, Long userId);
+
+    List<Photo> findByIdInAndUserId(List<Long> ids, Long userId);
+}

--- a/src/main/java/com/min/chalkakserver/service/FileUploadService.java
+++ b/src/main/java/com/min/chalkakserver/service/FileUploadService.java
@@ -1,17 +1,28 @@
 package com.min.chalkakserver.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import net.coobird.thumbnailator.Thumbnails;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 @Service
 public class FileUploadService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileUploadService.class);
 
     private final S3Client s3Client;
 
@@ -20,6 +31,10 @@ public class FileUploadService {
 
     @Value("${cloud.aws.region.static}")
     private String region;
+
+    // MinIO 등 커스텀 엔드포인트. 있으면 path-style URL을 생성한다.
+    @Value("${cloud.aws.s3.endpoint:}")
+    private String endpoint;
 
     public FileUploadService(S3Client s3Client) {
         this.s3Client = s3Client;
@@ -42,6 +57,94 @@ public class FileUploadService {
         s3Client.putObject(putObjectRequest,
                 RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
+        return buildPublicUrl(key);
+    }
+
+    /**
+     * 원본 이미지를 ~500x500 이내로 리사이즈한 썸네일(JPEG)을 S3/MinIO에 업로드한다.
+     * 키 포맷: {directory}/{UUID}_thumb.jpg
+     * 읽을 수 없는 포맷(HEIC 등) 등 어떤 예외가 발생하면 경고 로깅 후 null을 반환한다.
+     * (호출부는 null이면 원본 이미지 URL로 폴백)
+     */
+    public String uploadThumbnail(MultipartFile file, String directory) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Thumbnails.of(file.getInputStream())
+                    .size(500, 500)
+                    .outputFormat("jpg")
+                    .toOutputStream(baos);
+
+            byte[] bytes = baos.toByteArray();
+            String key = directory + "/" + UUID.randomUUID() + "_thumb.jpg";
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType("image/jpeg")
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(bytes));
+
+            return buildPublicUrl(key);
+        } catch (Exception e) {
+            log.warn("썸네일 생성/업로드 실패 (원본 URL로 폴백): directory={}, error={}", directory, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * S3 key에 대한 public URL을 생성한다.
+     * MinIO 등 커스텀 엔드포인트면 path-style URL, 아니면 실제 AWS virtual-hosted URL.
+     */
+    private String buildPublicUrl(String key) {
+        if (endpoint != null && !endpoint.isBlank()) {
+            String base = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+            return String.format("%s/%s/%s", base, bucket, key);
+        }
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+    }
+
+    /**
+     * S3에 저장된 객체를 public URL 기준으로 삭제한다.
+     * URL 포맷: https://{bucket}.s3.{region}.amazonaws.com/{key}
+     * null/blank/파싱 불가 시 no-op (경고 로깅).
+     */
+    public void deleteFile(String url) {
+        if (url == null || url.isBlank()) {
+            return;
+        }
+
+        try {
+            URI uri = URI.create(url);
+            String path = uri.getPath();
+            if (path == null || path.isBlank() || "/".equals(path)) {
+                log.warn("S3 삭제 스킵: URL에서 key를 추출할 수 없습니다. url={}", url);
+                return;
+            }
+
+            // 선행 슬래시 제거 후 URL 디코딩하여 실제 S3 key 복원
+            String key = path.startsWith("/") ? path.substring(1) : path;
+            key = URLDecoder.decode(key, StandardCharsets.UTF_8);
+
+            // path-style(MinIO) URL이면 앞의 "{bucket}/" 를 제거해 순수 key만 남긴다.
+            String bucketPrefix = bucket + "/";
+            if (key.startsWith(bucketPrefix)) {
+                key = key.substring(bucketPrefix.length());
+            }
+
+            if (key.isBlank()) {
+                log.warn("S3 삭제 스킵: 비어있는 key. url={}", url);
+                return;
+            }
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
+            log.warn("S3 객체 삭제 실패 (무시하고 계속): url={}, error={}", url, e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/min/chalkakserver/service/PhotoAlbumService.java
+++ b/src/main/java/com/min/chalkakserver/service/PhotoAlbumService.java
@@ -1,0 +1,176 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.album.PhotoResponseDto;
+import com.min.chalkakserver.dto.album.PhotoUpdateRequestDto;
+import com.min.chalkakserver.entity.Photo;
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.repository.PhotoRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoAlbumService {
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    private final PhotoRepository photoRepository;
+    private final UserRepository userRepository;
+    private final FileUploadService fileUploadService;
+
+    /**
+     * 사진 업로드 (파일 → S3 → 사진첩 저장)
+     */
+    @Transactional
+    public PhotoResponseDto uploadPhoto(Long userId, MultipartFile file, String memo, LocalDateTime photoDate) throws IOException {
+        validateImageFile(file);
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException("사용자를 찾을 수 없습니다.", "NOT_FOUND"));
+
+        String dir = "albums/" + userId;
+        String imageUrl = fileUploadService.uploadFile(file, dir);
+
+        String thumbnailUrl = fileUploadService.uploadThumbnail(file, dir);
+        if (thumbnailUrl == null) {
+            thumbnailUrl = imageUrl;
+        }
+
+        Photo photo = Photo.builder()
+            .user(user)
+            .imageUrl(imageUrl)
+            .thumbnailUrl(thumbnailUrl)
+            .memo(memo)
+            .favorite(false)
+            .source(Photo.PhotoSource.FILE_UPLOAD)
+            .photoDate(photoDate)
+            .build();
+
+        Photo savedPhoto = photoRepository.save(photo);
+        log.info("Album photo uploaded: userId={}, photoId={}", userId, savedPhoto.getId());
+
+        return PhotoResponseDto.from(savedPhoto);
+    }
+
+    /**
+     * 내 사진 목록 조회 (createdAt DESC)
+     */
+    @Transactional(readOnly = true)
+    public List<PhotoResponseDto> getMyPhotos(Long userId, boolean favoriteOnly) {
+        List<Photo> photos = favoriteOnly
+            ? photoRepository.findByUserIdAndFavoriteTrueOrderByCreatedAtDesc(userId)
+            : photoRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        return photos.stream()
+            .map(PhotoResponseDto::from)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * 내 사진 목록 조회 (페이징, createdAt DESC)
+     */
+    @Transactional(readOnly = true)
+    public PagedResponseDto<PhotoResponseDto> getMyPhotosPaged(
+            Long userId, boolean favoriteOnly, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<Photo> photoPage = favoriteOnly
+            ? photoRepository.findByUserIdAndFavoriteTrue(userId, pageable)
+            : photoRepository.findByUserId(userId, pageable);
+
+        return PagedResponseDto.from(photoPage.map(PhotoResponseDto::from));
+    }
+
+    /**
+     * 사진 부분 수정 (memo / favorite, null이 아닌 필드만 반영)
+     */
+    @Transactional
+    public PhotoResponseDto updatePhoto(Long userId, Long photoId, PhotoUpdateRequestDto request) {
+        Photo photo = photoRepository.findByIdAndUserId(photoId, userId)
+            .orElseThrow(() -> new AuthException("해당 사진을 찾을 수 없습니다.", "NOT_FOUND"));
+
+        if (request.getMemo() != null) {
+            photo.updateMemo(request.getMemo());
+        }
+        if (request.getFavorite() != null) {
+            photo.updateFavorite(request.getFavorite());
+        }
+
+        log.info("Album photo updated: userId={}, photoId={}", userId, photoId);
+        return PhotoResponseDto.from(photo);
+    }
+
+    /**
+     * 사진 단건 삭제 (소유자만, S3 객체도 정리)
+     */
+    @Transactional
+    public void deletePhoto(Long userId, Long photoId) {
+        Photo photo = photoRepository.findByIdAndUserId(photoId, userId)
+            .orElseThrow(() -> new AuthException("해당 사진을 찾을 수 없습니다.", "NOT_FOUND"));
+
+        deletePhotoObjects(photo);
+        photoRepository.delete(photo);
+        log.info("Album photo deleted: userId={}, photoId={}", userId, photoId);
+    }
+
+    /**
+     * 사진 다중 삭제 (본인 소유만 삭제, 타인/없는 id는 조용히 스킵)
+     */
+    @Transactional
+    public void deletePhotos(Long userId, List<Long> ids) {
+        List<Photo> photos = photoRepository.findByIdInAndUserId(ids, userId);
+
+        for (Photo photo : photos) {
+            deletePhotoObjects(photo);
+        }
+
+        photoRepository.deleteAll(photos);
+        log.info("Album photos bulk deleted: userId={}, requested={}, deleted={}",
+            userId, ids.size(), photos.size());
+    }
+
+    /**
+     * 사진에 연결된 S3 객체(원본 + 썸네일)를 정리한다.
+     * 썸네일이 원본 URL로 폴백된 경우(동일 URL)는 중복 삭제하지 않는다.
+     */
+    private void deletePhotoObjects(Photo photo) {
+        String imageUrl = photo.getImageUrl();
+        String thumbnailUrl = photo.getThumbnailUrl();
+
+        fileUploadService.deleteFile(imageUrl);
+        if (thumbnailUrl != null && !thumbnailUrl.equals(imageUrl)) {
+            fileUploadService.deleteFile(thumbnailUrl);
+        }
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new IllegalArgumentException("이미지 파일만 업로드 가능합니다.");
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 변경사항
- 네컷 사진첩 API `/api/album/photos` 추가 — 업로드(multipart), 목록(찜 필터·페이징), 부분수정(메모/찜), 단건·벌크 삭제
- 업로드 시 S3(MinIO 호환) 저장 + `thumbnailator` 썸네일 생성, `Photo` 엔티티에 메모·찜·촬영일 관리
- 로컬 개발용 `docker-compose`에 MySQL·MinIO 서비스 추가

## 제외
- `application-local.yml`(개인 로컬 설정)·`.DS_Store`는 커밋에서 제외