### PR TITLE
feat: 비밀번호 재설정 및 가입방식 조회 API

### DIFF
--- a/src/main/java/com/min/chalkakserver/config/RateLimitInterceptor.java
+++ b/src/main/java/com/min/chalkakserver/config/RateLimitInterceptor.java
@@ -28,8 +28,10 @@ public class RateLimitInterceptor implements HandlerInterceptor {
 
         // API 종류에 따른 Rate Limit 적용
         Bucket bucket;
-        if (requestUri.contains("/auth/login") || requestUri.contains("/auth/refresh")) {
-            // 인증 API: 브루트포스 공격 방지를 위한 엄격한 제한
+        if (requestUri.contains("/auth/login") || requestUri.contains("/auth/refresh")
+                || requestUri.contains("/auth/password/reset/request")
+                || requestUri.contains("/auth/find-provider")) {
+            // 인증 API: 브루트포스 공격 방지 및 이메일 열거/폭탄 방지를 위한 엄격한 제한
             bucket = rateLimitConfig.resolveAuthBucket(ipAddress);
         } else if (requestUri.contains("/report")) {
             // 제보 API: 스팸 방지

--- a/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
+++ b/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 // 인증 관련 엔드포인트 허용
                 .requestMatchers("/api/auth/login", "/api/auth/login/email", "/api/auth/register", "/api/auth/refresh", "/api/auth/logout").permitAll()
+                // 비밀번호 재설정 및 가입 수단 찾기 (인증 불필요)
+                .requestMatchers("/api/auth/password/**", "/api/auth/find-provider").permitAll()
                 // 사진관 제보 현황은 인증 필요 (wildcard보다 먼저 선언)
                 .requestMatchers(HttpMethod.GET, "/api/photo-booths/reports/**").authenticated()
                 // 포토부스 조회 API는 인증 없이 허용 (GET만)

--- a/src/main/java/com/min/chalkakserver/controller/AuthController.java
+++ b/src/main/java/com/min/chalkakserver/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.min.chalkakserver.controller;
 import com.min.chalkakserver.dto.auth.*;
 import com.min.chalkakserver.security.CustomUserDetails;
 import com.min.chalkakserver.service.AuthService;
+import com.min.chalkakserver.service.PasswordResetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @Tag(name = "Auth", description = "인증 API")
@@ -21,6 +23,7 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+    private final PasswordResetService passwordResetService;
 
     @Operation(summary = "소셜 로그인", description = "카카오/네이버/애플 소셜 로그인")
     @PostMapping("/login")
@@ -96,6 +99,42 @@ public class AuthController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         authService.deleteAccount(userDetails.getId());
         return ResponseEntity.ok(Map.of("message", "회원 탈퇴가 완료되었습니다."));
+    }
+
+    @Operation(summary = "비밀번호 재설정 요청", description = "이메일로 6자리 인증코드 발송 (계정 존재 여부와 무관하게 200 반환)")
+    @PostMapping("/password/reset/request")
+    public ResponseEntity<Map<String, String>> requestPasswordReset(
+            @Valid @RequestBody PasswordResetRequestDto request) {
+        passwordResetService.requestReset(request.getEmail());
+        return ResponseEntity.ok(Map.of("message", "인증코드가 발송되었습니다. 이메일을 확인해주세요."));
+    }
+
+    @Operation(summary = "비밀번호 재설정 인증코드 검증", description = "인증코드 검증 후 리셋 토큰 발급")
+    @PostMapping("/password/reset/verify")
+    public ResponseEntity<PasswordResetVerifyResponseDto> verifyPasswordResetCode(
+            @Valid @RequestBody PasswordResetVerifyRequestDto request) {
+        String resetToken = passwordResetService.verifyCode(request.getEmail(), request.getCode());
+        return ResponseEntity.ok(PasswordResetVerifyResponseDto.builder()
+            .resetToken(resetToken)
+            .build());
+    }
+
+    @Operation(summary = "비밀번호 재설정 확정", description = "리셋 토큰으로 새 비밀번호 설정")
+    @PostMapping("/password/reset/confirm")
+    public ResponseEntity<Map<String, String>> confirmPasswordReset(
+            @Valid @RequestBody PasswordResetConfirmRequestDto request) {
+        passwordResetService.confirmReset(request.getResetToken(), request.getNewPassword());
+        return ResponseEntity.ok(Map.of("message", "비밀번호가 재설정되었습니다."));
+    }
+
+    @Operation(summary = "가입 수단 찾기", description = "이메일로 가입된 로그인 수단(provider) 목록 조회")
+    @PostMapping("/find-provider")
+    public ResponseEntity<FindProviderResponseDto> findProvider(
+            @Valid @RequestBody FindProviderRequestDto request) {
+        List<String> providers = passwordResetService.findProviders(request.getEmail());
+        return ResponseEntity.ok(FindProviderResponseDto.builder()
+            .providers(providers)
+            .build());
     }
 
     @Operation(summary = "프로필 수정", description = "닉네임 등 프로필 정보 수정")

--- a/src/main/java/com/min/chalkakserver/dto/auth/FindProviderRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/FindProviderRequestDto.java
@@ -1,0 +1,19 @@
+package com.min.chalkakserver.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindProviderRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/FindProviderResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/FindProviderResponseDto.java
@@ -1,0 +1,17 @@
+package com.min.chalkakserver.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindProviderResponseDto {
+
+    private List<String> providers;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetConfirmRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetConfirmRequestDto.java
@@ -1,0 +1,22 @@
+package com.min.chalkakserver.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetConfirmRequestDto {
+
+    @NotBlank(message = "리셋 토큰은 필수입니다")
+    private String resetToken;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
+    private String newPassword;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetRequestDto.java
@@ -1,0 +1,19 @@
+package com.min.chalkakserver.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetVerifyRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetVerifyRequestDto.java
@@ -1,0 +1,20 @@
+package com.min.chalkakserver.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetVerifyRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    private String email;
+
+    @NotBlank(message = "인증코드는 필수입니다")
+    private String code;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetVerifyResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetVerifyResponseDto.java
@@ -1,0 +1,15 @@
+package com.min.chalkakserver.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetVerifyResponseDto {
+
+    private String resetToken;
+}

--- a/src/main/java/com/min/chalkakserver/entity/User.java
+++ b/src/main/java/com/min/chalkakserver/entity/User.java
@@ -111,6 +111,10 @@ public class User {
         this.lastLoginAt = LocalDateTime.now();
     }
 
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
     public void updateRole(Role role) {
         this.role = role;
     }

--- a/src/main/java/com/min/chalkakserver/repository/UserRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/UserRepository.java
@@ -8,14 +8,18 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    
+
     Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
-    
+
     Optional<User> findByEmail(String email);
+
+    // 동일 이메일로 가입된 모든 계정 조회 (email은 unique 제약이 없음 - provider별 중복 가능)
+    List<User> findAllByEmail(String email);
     
     // 이메일 회원가입 시 중복 체크용
     Optional<User> findByEmailAndProvider(String email, AuthProvider provider);

--- a/src/main/java/com/min/chalkakserver/service/EmailService.java
+++ b/src/main/java/com/min/chalkakserver/service/EmailService.java
@@ -43,6 +43,40 @@ public class EmailService {
         }
     }
 
+    @Async
+    public void sendPasswordResetCode(String toEmail, String code) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(toEmail);
+            helper.setSubject("[찰칵] 비밀번호 재설정 인증코드");
+            helper.setText(buildPasswordResetEmailContent(code), true);
+
+            mailSender.send(message);
+            log.info("비밀번호 재설정 인증코드 전송 성공: {}", escapeForLog(toEmail));
+        } catch (MessagingException | RuntimeException e) {
+            // @Async 메서드에서는 예외를 던져도 호출자에게 전달되지 않으므로 로깅만 수행
+            log.error("비밀번호 재설정 인증코드 전송 실패: {}", escapeForLog(toEmail), e);
+        }
+    }
+
+    private String buildPasswordResetEmailContent(String code) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body>");
+        sb.append("<h2>비밀번호 재설정 인증코드</h2>");
+        sb.append("<p>아래 6자리 인증코드를 입력해 비밀번호를 재설정해주세요.</p>");
+        sb.append("<p style='font-size: 28px; font-weight: bold; letter-spacing: 4px;'>")
+            .append(escapeHtml(code))
+            .append("</p>");
+        sb.append("<p style='color: gray;'>이 인증코드는 5분간 유효합니다.</p>");
+        sb.append("<hr>");
+        sb.append(
+            "<p style='color: gray; font-size: 12px;'>본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.</p>");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
     /**
      * HTML 이스케이프 처리 - XSS 방지
      */

--- a/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
+++ b/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
@@ -1,0 +1,114 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.entity.User.AuthProvider;
+import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.repository.RefreshTokenRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 이메일 기반 비밀번호 재설정 및 가입 수단(provider) 조회 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    private static final String CODE_KEY_PREFIX = "pwreset:code:";
+    private static final String TOKEN_KEY_PREFIX = "pwreset:token:";
+    private static final Duration CODE_TTL = Duration.ofMinutes(5);
+    private static final Duration TOKEN_TTL = Duration.ofMinutes(10);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+    private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    /**
+     * 비밀번호 재설정 요청 - 인증코드 발송
+     * 이메일 열거(enumeration) 방지를 위해 계정 존재 여부와 무관하게 정상 반환한다.
+     */
+    public void requestReset(String email) {
+        userRepository.findByEmailAndProvider(email, AuthProvider.EMAIL)
+            .ifPresentOrElse(user -> {
+                String code = generateCode();
+                redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
+                emailService.sendPasswordResetCode(email, code);
+                // 로컬 테스트용: 실제 SMTP 없이도 코드 확인 가능하도록 로그 출력
+                log.info("[DEV] 비밀번호 재설정 인증코드 생성: email={}, code={}", email, code);
+            }, () -> log.info("비밀번호 재설정 요청 - 존재하지 않는 이메일 계정 (무시): {}", email));
+    }
+
+    /**
+     * 인증코드 검증 - 성공 시 리셋 토큰 발급
+     */
+    public String verifyCode(String email, String code) {
+        Object stored = redisTemplate.opsForValue().get(CODE_KEY_PREFIX + email);
+        if (stored == null || !Objects.equals(stored.toString(), code)) {
+            throw new AuthException("인증코드가 올바르지 않거나 만료되었습니다", "UNAUTHORIZED");
+        }
+
+        String resetToken = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(TOKEN_KEY_PREFIX + resetToken, email, TOKEN_TTL);
+        redisTemplate.delete(CODE_KEY_PREFIX + email);
+
+        log.info("비밀번호 재설정 인증코드 검증 성공: {}", email);
+        return resetToken;
+    }
+
+    /**
+     * 리셋 토큰으로 새 비밀번호 확정
+     */
+    @Transactional
+    public void confirmReset(String resetToken, String newPassword) {
+        Object emailObj = redisTemplate.opsForValue().get(TOKEN_KEY_PREFIX + resetToken);
+        if (emailObj == null) {
+            throw new AuthException("리셋 토큰이 올바르지 않거나 만료되었습니다", "UNAUTHORIZED");
+        }
+        String email = emailObj.toString();
+
+        User user = userRepository.findByEmailAndProvider(email, AuthProvider.EMAIL)
+            .orElseThrow(() -> new AuthException("사용자를 찾을 수 없습니다", "NOT_FOUND"));
+
+        user.updatePassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        redisTemplate.delete(TOKEN_KEY_PREFIX + resetToken);
+
+        // 비밀번호 변경 시 모든 기기 로그아웃 (기존 refresh token 무효화)
+        refreshTokenRepository.deleteAllByUser(user);
+
+        log.info("비밀번호 재설정 완료: userId={}", user.getId());
+    }
+
+    /**
+     * 이메일로 가입된 provider 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<String> findProviders(String email) {
+        return userRepository.findAllByEmail(email).stream()
+            .map(user -> user.getProvider().name())
+            .distinct()
+            .collect(Collectors.toList());
+    }
+
+    private String generateCode() {
+        return String.format("%06d", secureRandom.nextInt(1_000_000));
+    }
+}


### PR DESCRIPTION
이메일 계정 비밀번호 재설정과 가입방식(provider) 안내용 인증 API 추가.

- **재설정**: 등록 이메일로 6자리 코드 발송(Redis 5분) → 검증 시 resetToken 발급(10분) → 새 비밀번호 저장 + 해당 유저 refresh 토큰 전량 폐기
- **find-provider**: 이메일이 어떤 소셜로 가입됐는지 조회 (로그인 실패 시 "카카오로 가입된 계정" 안내에 사용)
- 전화/본인인증 없이 **이메일 인증만**. 신규 엔드포인트는 permitAll + Auth 레이트리밋 적용

> base: `dev` (main에서 분기). 로컬은 메일 dummy라 인증코드가 서버 로그에 `[DEV]`로 출력됨.