### PR TITLE
release: 운영 배포

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     // AWS S3
     implementation 'software.amazon.awssdk:s3:2.25.27'
 
+    // Thumbnail 생성
+    implementation 'net.coobird:thumbnailator:0.4.20'
+
     // Firebase Admin SDK
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,73 @@ services:
     networks:
       - chalkak-network
 
+  # ── 로컬 개발용 MySQL ──────────────────────────────────────────────
+  # application.yml 기본값과 일치: chalkak_db / chalkak / chalkak123
+  mysql:
+    image: mysql:8.0
+    container_name: chalkak-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: chalkak_db
+      MYSQL_USER: chalkak
+      MYSQL_PASSWORD: chalkak123
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uchalkak", "-pchalkak123"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - chalkak-network
+
+  # ── 로컬 개발용 MinIO (S3 호환 오브젝트 스토리지) ─────────────────
+  # API :9000 / 콘솔 :9001 (minioadmin / minioadmin)
+  minio:
+    image: minio/minio:latest
+    container_name: chalkak-minio
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - chalkak-network
+
+  # 버킷 자동 생성 + 익명 read 허용 (앱이 반환하는 public 이미지 URL 로딩용)
+  createbuckets:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc alias set local http://minio:9000 minioadmin minioadmin;
+      /usr/bin/mc mb -p local/chalkak-uploads;
+      /usr/bin/mc anonymous set download local/chalkak-uploads;
+      exit 0;
+      "
+    networks:
+      - chalkak-network
+
 volumes:
   redis_data:
+    driver: local
+  mysql_data:
+    driver: local
+  minio_data:
     driver: local
 
 networks:

--- a/src/main/java/com/min/chalkakserver/config/RateLimitInterceptor.java
+++ b/src/main/java/com/min/chalkakserver/config/RateLimitInterceptor.java
@@ -28,8 +28,10 @@ public class RateLimitInterceptor implements HandlerInterceptor {
 
         // API 종류에 따른 Rate Limit 적용
         Bucket bucket;
-        if (requestUri.contains("/auth/login") || requestUri.contains("/auth/refresh")) {
-            // 인증 API: 브루트포스 공격 방지를 위한 엄격한 제한
+        if (requestUri.contains("/auth/login") || requestUri.contains("/auth/refresh")
+                || requestUri.contains("/auth/password/reset/request")
+                || requestUri.contains("/auth/find-provider")) {
+            // 인증 API: 브루트포스 공격 방지 및 이메일 열거/폭탄 방지를 위한 엄격한 제한
             bucket = rateLimitConfig.resolveAuthBucket(ipAddress);
         } else if (requestUri.contains("/report")) {
             // 제보 API: 스팸 방지

--- a/src/main/java/com/min/chalkakserver/config/S3Config.java
+++ b/src/main/java/com/min/chalkakserver/config/S3Config.java
@@ -7,6 +7,10 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
 
 @Configuration
 public class S3Config {
@@ -20,12 +24,26 @@ public class S3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    // 로컬 MinIO 등 S3 호환 스토리지용 커스텀 엔드포인트. 비어있으면 실제 AWS S3 사용.
+    @Value("${cloud.aws.s3.endpoint:}")
+    private String endpoint;
+
     @Bean
     public S3Client s3Client() {
-        return S3Client.builder()
+        S3ClientBuilder builder = S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
-                .build();
+                        AwsBasicCredentials.create(accessKey, secretKey)));
+
+        // 엔드포인트가 지정된 경우(MinIO 등)만 오버라이드 + path-style 접근.
+        if (endpoint != null && !endpoint.isBlank()) {
+            builder = builder
+                    .endpointOverride(URI.create(endpoint))
+                    .serviceConfiguration(S3Configuration.builder()
+                            .pathStyleAccessEnabled(true)
+                            .build());
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
+++ b/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
@@ -54,6 +54,8 @@ public class SecurityConfig {
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                 // 인증 관련 엔드포인트 허용
                 .requestMatchers("/api/auth/login", "/api/auth/login/email", "/api/auth/register", "/api/auth/refresh", "/api/auth/logout").permitAll()
+                // 비밀번호 재설정 및 가입 수단 찾기 (인증 불필요)
+                .requestMatchers("/api/auth/password/**", "/api/auth/find-provider").permitAll()
                 // 사진관 제보 현황은 인증 필요 (wildcard보다 먼저 선언)
                 .requestMatchers(HttpMethod.GET, "/api/photo-booths/reports/**").authenticated()
                 // 포토부스 조회 API는 인증 없이 허용 (GET만)

--- a/src/main/java/com/min/chalkakserver/controller/AuthController.java
+++ b/src/main/java/com/min/chalkakserver/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.min.chalkakserver.controller;
 import com.min.chalkakserver.dto.auth.*;
 import com.min.chalkakserver.security.CustomUserDetails;
 import com.min.chalkakserver.service.AuthService;
+import com.min.chalkakserver.service.PasswordResetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @Tag(name = "Auth", description = "인증 API")
@@ -21,6 +23,7 @@ import java.util.Map;
 public class AuthController {
 
     private final AuthService authService;
+    private final PasswordResetService passwordResetService;
 
     @Operation(summary = "소셜 로그인", description = "카카오/네이버/애플 소셜 로그인")
     @PostMapping("/login")
@@ -96,6 +99,42 @@ public class AuthController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         authService.deleteAccount(userDetails.getId());
         return ResponseEntity.ok(Map.of("message", "회원 탈퇴가 완료되었습니다."));
+    }
+
+    @Operation(summary = "비밀번호 재설정 요청", description = "이메일로 6자리 인증코드 발송 (계정 존재 여부와 무관하게 200 반환)")
+    @PostMapping("/password/reset/request")
+    public ResponseEntity<Map<String, String>> requestPasswordReset(
+            @Valid @RequestBody PasswordResetRequestDto request) {
+        passwordResetService.requestReset(request.getEmail());
+        return ResponseEntity.ok(Map.of("message", "인증코드가 발송되었습니다. 이메일을 확인해주세요."));
+    }
+
+    @Operation(summary = "비밀번호 재설정 인증코드 검증", description = "인증코드 검증 후 리셋 토큰 발급")
+    @PostMapping("/password/reset/verify")
+    public ResponseEntity<PasswordResetVerifyResponseDto> verifyPasswordResetCode(
+            @Valid @RequestBody PasswordResetVerifyRequestDto request) {
+        String resetToken = passwordResetService.verifyCode(request.getEmail(), request.getCode());
+        return ResponseEntity.ok(PasswordResetVerifyResponseDto.builder()
+            .resetToken(resetToken)
+            .build());
+    }
+
+    @Operation(summary = "비밀번호 재설정 확정", description = "리셋 토큰으로 새 비밀번호 설정")
+    @PostMapping("/password/reset/confirm")
+    public ResponseEntity<Map<String, String>> confirmPasswordReset(
+            @Valid @RequestBody PasswordResetConfirmRequestDto request) {
+        passwordResetService.confirmReset(request.getResetToken(), request.getNewPassword());
+        return ResponseEntity.ok(Map.of("message", "비밀번호가 재설정되었습니다."));
+    }
+
+    @Operation(summary = "가입 수단 찾기", description = "이메일로 가입된 로그인 수단(provider) 목록 조회")
+    @PostMapping("/find-provider")
+    public ResponseEntity<FindProviderResponseDto> findProvider(
+            @Valid @RequestBody FindProviderRequestDto request) {
+        List<String> providers = passwordResetService.findProviders(request.getEmail());
+        return ResponseEntity.ok(FindProviderResponseDto.builder()
+            .providers(providers)
+            .build());
     }
 
     @Operation(summary = "프로필 수정", description = "닉네임 등 프로필 정보 수정")

--- a/src/main/java/com/min/chalkakserver/controller/PhotoAlbumController.java
+++ b/src/main/java/com/min/chalkakserver/controller/PhotoAlbumController.java
@@ -1,0 +1,104 @@
+package com.min.chalkakserver.controller;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.album.PhotoBulkDeleteRequestDto;
+import com.min.chalkakserver.dto.album.PhotoResponseDto;
+import com.min.chalkakserver.dto.album.PhotoUpdateRequestDto;
+import com.min.chalkakserver.security.CustomUserDetails;
+import com.min.chalkakserver.service.PhotoAlbumService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+@Tag(name = "Photo Album", description = "네컷 사진첩 API")
+@RestController
+@RequestMapping("/api/album/photos")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+@Slf4j
+public class PhotoAlbumController {
+
+    private final PhotoAlbumService photoAlbumService;
+
+    @Operation(summary = "사진 업로드", description = "네컷 이미지 파일 업로드 (로그인 필요)")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PhotoResponseDto> uploadPhoto(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "memo", required = false) String memo,
+            @RequestParam(value = "photoDate", required = false) String photoDate) throws IOException {
+        LocalDateTime parsedPhotoDate = null;
+        if (photoDate != null && !photoDate.isBlank()) {
+            try {
+                parsedPhotoDate = LocalDateTime.parse(photoDate);
+            } catch (DateTimeParseException e) {
+                log.warn("Invalid photoDate ignored: value={}, reason={}", photoDate, e.getMessage());
+            }
+        }
+        PhotoResponseDto response = photoAlbumService.uploadPhoto(userDetails.getId(), file, memo, parsedPhotoDate);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @Operation(summary = "내 사진 목록", description = "내 사진첩 목록 조회 (createdAt DESC), favorite=true 시 찜만 (로그인 필요)")
+    @GetMapping
+    public ResponseEntity<List<PhotoResponseDto>> getMyPhotos(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(value = "favorite", defaultValue = "false") boolean favorite) {
+        List<PhotoResponseDto> response = photoAlbumService.getMyPhotos(userDetails.getId(), favorite);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "내 사진 목록 (페이징)", description = "내 사진첩 목록 페이징 조회 (로그인 필요)")
+    @GetMapping("/paged")
+    public ResponseEntity<PagedResponseDto<PhotoResponseDto>> getMyPhotosPaged(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(value = "favorite", defaultValue = "false") boolean favorite) {
+        PagedResponseDto<PhotoResponseDto> response =
+            photoAlbumService.getMyPhotosPaged(userDetails.getId(), favorite, page, size);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "사진 수정", description = "메모/찜 부분 수정 (로그인 필요)")
+    @PatchMapping("/{id}")
+    public ResponseEntity<PhotoResponseDto> updatePhoto(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id,
+            @Valid @RequestBody PhotoUpdateRequestDto request) {
+        PhotoResponseDto response = photoAlbumService.updatePhoto(userDetails.getId(), id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "사진 삭제", description = "내 사진 단건 삭제 (S3 객체 포함, 로그인 필요)")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePhoto(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id) {
+        photoAlbumService.deletePhoto(userDetails.getId(), id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "사진 다중 삭제", description = "선택한 사진 벌크 삭제 (본인 소유만, 로그인 필요)")
+    @DeleteMapping
+    public ResponseEntity<Void> deletePhotos(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PhotoBulkDeleteRequestDto request) {
+        photoAlbumService.deletePhotos(userDetails.getId(), request.getIds());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/album/PhotoBulkDeleteRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/album/PhotoBulkDeleteRequestDto.java
@@ -1,0 +1,19 @@
+package com.min.chalkakserver.dto.album;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoBulkDeleteRequestDto {
+
+    @NotEmpty(message = "삭제할 사진 ID 목록이 비어있습니다.")
+    private List<Long> ids;
+}

--- a/src/main/java/com/min/chalkakserver/dto/album/PhotoResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/album/PhotoResponseDto.java
@@ -1,0 +1,37 @@
+package com.min.chalkakserver.dto.album;
+
+import com.min.chalkakserver.entity.Photo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoResponseDto {
+    private Long id;
+    private String imageUrl;
+    private String thumbnailUrl;
+    private String memo;
+    private boolean favorite;
+    private Photo.PhotoSource source;
+    private LocalDateTime photoDate;
+    private LocalDateTime createdAt;
+
+    public static PhotoResponseDto from(Photo photo) {
+        return PhotoResponseDto.builder()
+            .id(photo.getId())
+            .imageUrl(photo.getImageUrl())
+            .thumbnailUrl(photo.getThumbnailUrl())
+            .memo(photo.getMemo())
+            .favorite(photo.isFavorite())
+            .source(photo.getSource())
+            .photoDate(photo.getPhotoDate())
+            .createdAt(photo.getCreatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/min/chalkakserver/dto/album/PhotoUpdateRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/album/PhotoUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package com.min.chalkakserver.dto.album;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PhotoUpdateRequestDto {
+
+    @Size(max = 50, message = "메모는 50자를 초과할 수 없습니다.")
+    private String memo;
+
+    private Boolean favorite;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/FindProviderRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/FindProviderRequestDto.java
@@ -1,0 +1,19 @@
+package com.min.chalkakserver.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindProviderRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/FindProviderResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/FindProviderResponseDto.java
@@ -1,0 +1,17 @@
+package com.min.chalkakserver.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindProviderResponseDto {
+
+    private List<String> providers;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetConfirmRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetConfirmRequestDto.java
@@ -1,0 +1,22 @@
+package com.min.chalkakserver.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetConfirmRequestDto {
+
+    @NotBlank(message = "리셋 토큰은 필수입니다")
+    private String resetToken;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
+    private String newPassword;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetRequestDto.java
@@ -1,0 +1,19 @@
+package com.min.chalkakserver.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetVerifyRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetVerifyRequestDto.java
@@ -1,0 +1,20 @@
+package com.min.chalkakserver.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetVerifyRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    private String email;
+
+    @NotBlank(message = "인증코드는 필수입니다")
+    private String code;
+}

--- a/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetVerifyResponseDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/PasswordResetVerifyResponseDto.java
@@ -1,0 +1,15 @@
+package com.min.chalkakserver.dto.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetVerifyResponseDto {
+
+    private String resetToken;
+}

--- a/src/main/java/com/min/chalkakserver/entity/Photo.java
+++ b/src/main/java/com/min/chalkakserver/entity/Photo.java
@@ -1,0 +1,89 @@
+package com.min.chalkakserver.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "photos",
+    indexes = {
+        @Index(name = "idx_photo_user_created", columnList = "user_id, created_at")
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Photo {
+
+    public enum PhotoSource {
+        FILE_UPLOAD, QR_DOWNLOAD
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(name = "thumbnail_url", length = 500)
+    private String thumbnailUrl;
+
+    @Column(length = 50)
+    private String memo;
+
+    @Column(name = "is_favorite")
+    private boolean favorite;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private PhotoSource source;
+
+    @Column(name = "photo_date")
+    private LocalDateTime photoDate;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+        if (photoDate == null) {
+            photoDate = createdAt;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Photo(User user, String imageUrl, String thumbnailUrl, String memo, boolean favorite, PhotoSource source, LocalDateTime photoDate) {
+        this.user = user;
+        this.imageUrl = imageUrl;
+        this.thumbnailUrl = thumbnailUrl;
+        this.memo = memo;
+        this.favorite = favorite;
+        this.source = source;
+        this.photoDate = photoDate;
+    }
+
+    public void updateMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public void updateFavorite(boolean favorite) {
+        this.favorite = favorite;
+    }
+}

--- a/src/main/java/com/min/chalkakserver/entity/PhotoBooth.java
+++ b/src/main/java/com/min/chalkakserver/entity/PhotoBooth.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.DynamicUpdate;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -65,7 +66,10 @@ public class PhotoBooth {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    // 목록 응답은 booth마다 태그를 읽으므로, 배치로 묶어 N+1을 방지한다
+    // (네이티브 쿼리 경로인 nearby/popular 포함 전 조회 경로에 적용됨)
     @ManyToMany(fetch = FetchType.LAZY)
+    @BatchSize(size = 200)
     @JoinTable(
         name = "photo_booth_tags",
         joinColumns = @JoinColumn(name = "photo_booth_id"),

--- a/src/main/java/com/min/chalkakserver/entity/User.java
+++ b/src/main/java/com/min/chalkakserver/entity/User.java
@@ -111,6 +111,10 @@ public class User {
         this.lastLoginAt = LocalDateTime.now();
     }
 
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
     public void updateRole(Role role) {
         this.role = role;
     }

--- a/src/main/java/com/min/chalkakserver/repository/PhotoBoothRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/PhotoBoothRepository.java
@@ -3,6 +3,7 @@ package com.min.chalkakserver.repository;
 import com.min.chalkakserver.entity.PhotoBooth;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,7 +13,13 @@ import java.util.List;
 
 @Repository
 public interface PhotoBoothRepository extends JpaRepository<PhotoBooth, Long> {
-    
+
+    // 전체 목록은 응답 변환 시 태그를 모두 읽으므로 한 번에 fetch join 한다
+    // (페이지네이션 경로는 컬렉션 fetch join 시 메모리 페이징이 발생하므로 @BatchSize에 맡긴다)
+    @Override
+    @EntityGraph(attributePaths = "tags")
+    List<PhotoBooth> findAll();
+
     // 브랜드로 검색
     List<PhotoBooth> findByBrandContainingIgnoreCase(String brand);
     

--- a/src/main/java/com/min/chalkakserver/repository/PhotoRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/PhotoRepository.java
@@ -1,0 +1,26 @@
+package com.min.chalkakserver.repository;
+
+import com.min.chalkakserver.entity.Photo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+
+    List<Photo> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    List<Photo> findByUserIdAndFavoriteTrueOrderByCreatedAtDesc(Long userId);
+
+    Page<Photo> findByUserId(Long userId, Pageable pageable);
+
+    Page<Photo> findByUserIdAndFavoriteTrue(Long userId, Pageable pageable);
+
+    Optional<Photo> findByIdAndUserId(Long id, Long userId);
+
+    List<Photo> findByIdInAndUserId(List<Long> ids, Long userId);
+}

--- a/src/main/java/com/min/chalkakserver/repository/UserRepository.java
+++ b/src/main/java/com/min/chalkakserver/repository/UserRepository.java
@@ -8,14 +8,18 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    
+
     Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
-    
+
     Optional<User> findByEmail(String email);
+
+    // 동일 이메일로 가입된 모든 계정 조회 (email은 unique 제약이 없음 - provider별 중복 가능)
+    List<User> findAllByEmail(String email);
     
     // 이메일 회원가입 시 중복 체크용
     Optional<User> findByEmailAndProvider(String email, AuthProvider provider);

--- a/src/main/java/com/min/chalkakserver/service/EmailService.java
+++ b/src/main/java/com/min/chalkakserver/service/EmailService.java
@@ -43,6 +43,40 @@ public class EmailService {
         }
     }
 
+    @Async
+    public void sendPasswordResetCode(String toEmail, String code) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(toEmail);
+            helper.setSubject("[찰칵] 비밀번호 재설정 인증코드");
+            helper.setText(buildPasswordResetEmailContent(code), true);
+
+            mailSender.send(message);
+            log.info("비밀번호 재설정 인증코드 전송 성공: {}", escapeForLog(toEmail));
+        } catch (MessagingException | RuntimeException e) {
+            // @Async 메서드에서는 예외를 던져도 호출자에게 전달되지 않으므로 로깅만 수행
+            log.error("비밀번호 재설정 인증코드 전송 실패: {}", escapeForLog(toEmail), e);
+        }
+    }
+
+    private String buildPasswordResetEmailContent(String code) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body>");
+        sb.append("<h2>비밀번호 재설정 인증코드</h2>");
+        sb.append("<p>아래 6자리 인증코드를 입력해 비밀번호를 재설정해주세요.</p>");
+        sb.append("<p style='font-size: 28px; font-weight: bold; letter-spacing: 4px;'>")
+            .append(escapeHtml(code))
+            .append("</p>");
+        sb.append("<p style='color: gray;'>이 인증코드는 5분간 유효합니다.</p>");
+        sb.append("<hr>");
+        sb.append(
+            "<p style='color: gray; font-size: 12px;'>본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.</p>");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
     /**
      * HTML 이스케이프 처리 - XSS 방지
      */

--- a/src/main/java/com/min/chalkakserver/service/FileUploadService.java
+++ b/src/main/java/com/min/chalkakserver/service/FileUploadService.java
@@ -1,17 +1,28 @@
 package com.min.chalkakserver.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import net.coobird.thumbnailator.Thumbnails;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 @Service
 public class FileUploadService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileUploadService.class);
 
     private final S3Client s3Client;
 
@@ -20,6 +31,10 @@ public class FileUploadService {
 
     @Value("${cloud.aws.region.static}")
     private String region;
+
+    // MinIO 등 커스텀 엔드포인트. 있으면 path-style URL을 생성한다.
+    @Value("${cloud.aws.s3.endpoint:}")
+    private String endpoint;
 
     public FileUploadService(S3Client s3Client) {
         this.s3Client = s3Client;
@@ -42,6 +57,94 @@ public class FileUploadService {
         s3Client.putObject(putObjectRequest,
                 RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
+        return buildPublicUrl(key);
+    }
+
+    /**
+     * 원본 이미지를 ~500x500 이내로 리사이즈한 썸네일(JPEG)을 S3/MinIO에 업로드한다.
+     * 키 포맷: {directory}/{UUID}_thumb.jpg
+     * 읽을 수 없는 포맷(HEIC 등) 등 어떤 예외가 발생하면 경고 로깅 후 null을 반환한다.
+     * (호출부는 null이면 원본 이미지 URL로 폴백)
+     */
+    public String uploadThumbnail(MultipartFile file, String directory) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Thumbnails.of(file.getInputStream())
+                    .size(500, 500)
+                    .outputFormat("jpg")
+                    .toOutputStream(baos);
+
+            byte[] bytes = baos.toByteArray();
+            String key = directory + "/" + UUID.randomUUID() + "_thumb.jpg";
+
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .contentType("image/jpeg")
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(bytes));
+
+            return buildPublicUrl(key);
+        } catch (Exception e) {
+            log.warn("썸네일 생성/업로드 실패 (원본 URL로 폴백): directory={}, error={}", directory, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * S3 key에 대한 public URL을 생성한다.
+     * MinIO 등 커스텀 엔드포인트면 path-style URL, 아니면 실제 AWS virtual-hosted URL.
+     */
+    private String buildPublicUrl(String key) {
+        if (endpoint != null && !endpoint.isBlank()) {
+            String base = endpoint.endsWith("/") ? endpoint.substring(0, endpoint.length() - 1) : endpoint;
+            return String.format("%s/%s/%s", base, bucket, key);
+        }
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
+    }
+
+    /**
+     * S3에 저장된 객체를 public URL 기준으로 삭제한다.
+     * URL 포맷: https://{bucket}.s3.{region}.amazonaws.com/{key}
+     * null/blank/파싱 불가 시 no-op (경고 로깅).
+     */
+    public void deleteFile(String url) {
+        if (url == null || url.isBlank()) {
+            return;
+        }
+
+        try {
+            URI uri = URI.create(url);
+            String path = uri.getPath();
+            if (path == null || path.isBlank() || "/".equals(path)) {
+                log.warn("S3 삭제 스킵: URL에서 key를 추출할 수 없습니다. url={}", url);
+                return;
+            }
+
+            // 선행 슬래시 제거 후 URL 디코딩하여 실제 S3 key 복원
+            String key = path.startsWith("/") ? path.substring(1) : path;
+            key = URLDecoder.decode(key, StandardCharsets.UTF_8);
+
+            // path-style(MinIO) URL이면 앞의 "{bucket}/" 를 제거해 순수 key만 남긴다.
+            String bucketPrefix = bucket + "/";
+            if (key.startsWith(bucketPrefix)) {
+                key = key.substring(bucketPrefix.length());
+            }
+
+            if (key.isBlank()) {
+                log.warn("S3 삭제 스킵: 비어있는 key. url={}", url);
+                return;
+            }
+
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
+            log.warn("S3 객체 삭제 실패 (무시하고 계속): url={}, error={}", url, e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
+++ b/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
@@ -1,0 +1,114 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.entity.User.AuthProvider;
+import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.repository.RefreshTokenRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 이메일 기반 비밀번호 재설정 및 가입 수단(provider) 조회 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    private static final String CODE_KEY_PREFIX = "pwreset:code:";
+    private static final String TOKEN_KEY_PREFIX = "pwreset:token:";
+    private static final Duration CODE_TTL = Duration.ofMinutes(5);
+    private static final Duration TOKEN_TTL = Duration.ofMinutes(10);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+    private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    /**
+     * 비밀번호 재설정 요청 - 인증코드 발송
+     * 이메일 열거(enumeration) 방지를 위해 계정 존재 여부와 무관하게 정상 반환한다.
+     */
+    public void requestReset(String email) {
+        userRepository.findByEmailAndProvider(email, AuthProvider.EMAIL)
+            .ifPresentOrElse(user -> {
+                String code = generateCode();
+                redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
+                emailService.sendPasswordResetCode(email, code);
+                // 로컬 테스트용: 실제 SMTP 없이도 코드 확인 가능하도록 로그 출력
+                log.info("[DEV] 비밀번호 재설정 인증코드 생성: email={}, code={}", email, code);
+            }, () -> log.info("비밀번호 재설정 요청 - 존재하지 않는 이메일 계정 (무시): {}", email));
+    }
+
+    /**
+     * 인증코드 검증 - 성공 시 리셋 토큰 발급
+     */
+    public String verifyCode(String email, String code) {
+        Object stored = redisTemplate.opsForValue().get(CODE_KEY_PREFIX + email);
+        if (stored == null || !Objects.equals(stored.toString(), code)) {
+            throw new AuthException("인증코드가 올바르지 않거나 만료되었습니다", "UNAUTHORIZED");
+        }
+
+        String resetToken = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(TOKEN_KEY_PREFIX + resetToken, email, TOKEN_TTL);
+        redisTemplate.delete(CODE_KEY_PREFIX + email);
+
+        log.info("비밀번호 재설정 인증코드 검증 성공: {}", email);
+        return resetToken;
+    }
+
+    /**
+     * 리셋 토큰으로 새 비밀번호 확정
+     */
+    @Transactional
+    public void confirmReset(String resetToken, String newPassword) {
+        Object emailObj = redisTemplate.opsForValue().get(TOKEN_KEY_PREFIX + resetToken);
+        if (emailObj == null) {
+            throw new AuthException("리셋 토큰이 올바르지 않거나 만료되었습니다", "UNAUTHORIZED");
+        }
+        String email = emailObj.toString();
+
+        User user = userRepository.findByEmailAndProvider(email, AuthProvider.EMAIL)
+            .orElseThrow(() -> new AuthException("사용자를 찾을 수 없습니다", "NOT_FOUND"));
+
+        user.updatePassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        redisTemplate.delete(TOKEN_KEY_PREFIX + resetToken);
+
+        // 비밀번호 변경 시 모든 기기 로그아웃 (기존 refresh token 무효화)
+        refreshTokenRepository.deleteAllByUser(user);
+
+        log.info("비밀번호 재설정 완료: userId={}", user.getId());
+    }
+
+    /**
+     * 이메일로 가입된 provider 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<String> findProviders(String email) {
+        return userRepository.findAllByEmail(email).stream()
+            .map(user -> user.getProvider().name())
+            .distinct()
+            .collect(Collectors.toList());
+    }
+
+    private String generateCode() {
+        return String.format("%06d", secureRandom.nextInt(1_000_000));
+    }
+}

--- a/src/main/java/com/min/chalkakserver/service/PhotoAlbumService.java
+++ b/src/main/java/com/min/chalkakserver/service/PhotoAlbumService.java
@@ -1,0 +1,176 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.dto.PagedResponseDto;
+import com.min.chalkakserver.dto.album.PhotoResponseDto;
+import com.min.chalkakserver.dto.album.PhotoUpdateRequestDto;
+import com.min.chalkakserver.entity.Photo;
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.repository.PhotoRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoAlbumService {
+
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    private final PhotoRepository photoRepository;
+    private final UserRepository userRepository;
+    private final FileUploadService fileUploadService;
+
+    /**
+     * 사진 업로드 (파일 → S3 → 사진첩 저장)
+     */
+    @Transactional
+    public PhotoResponseDto uploadPhoto(Long userId, MultipartFile file, String memo, LocalDateTime photoDate) throws IOException {
+        validateImageFile(file);
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new AuthException("사용자를 찾을 수 없습니다.", "NOT_FOUND"));
+
+        String dir = "albums/" + userId;
+        String imageUrl = fileUploadService.uploadFile(file, dir);
+
+        String thumbnailUrl = fileUploadService.uploadThumbnail(file, dir);
+        if (thumbnailUrl == null) {
+            thumbnailUrl = imageUrl;
+        }
+
+        Photo photo = Photo.builder()
+            .user(user)
+            .imageUrl(imageUrl)
+            .thumbnailUrl(thumbnailUrl)
+            .memo(memo)
+            .favorite(false)
+            .source(Photo.PhotoSource.FILE_UPLOAD)
+            .photoDate(photoDate)
+            .build();
+
+        Photo savedPhoto = photoRepository.save(photo);
+        log.info("Album photo uploaded: userId={}, photoId={}", userId, savedPhoto.getId());
+
+        return PhotoResponseDto.from(savedPhoto);
+    }
+
+    /**
+     * 내 사진 목록 조회 (createdAt DESC)
+     */
+    @Transactional(readOnly = true)
+    public List<PhotoResponseDto> getMyPhotos(Long userId, boolean favoriteOnly) {
+        List<Photo> photos = favoriteOnly
+            ? photoRepository.findByUserIdAndFavoriteTrueOrderByCreatedAtDesc(userId)
+            : photoRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        return photos.stream()
+            .map(PhotoResponseDto::from)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * 내 사진 목록 조회 (페이징, createdAt DESC)
+     */
+    @Transactional(readOnly = true)
+    public PagedResponseDto<PhotoResponseDto> getMyPhotosPaged(
+            Long userId, boolean favoriteOnly, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<Photo> photoPage = favoriteOnly
+            ? photoRepository.findByUserIdAndFavoriteTrue(userId, pageable)
+            : photoRepository.findByUserId(userId, pageable);
+
+        return PagedResponseDto.from(photoPage.map(PhotoResponseDto::from));
+    }
+
+    /**
+     * 사진 부분 수정 (memo / favorite, null이 아닌 필드만 반영)
+     */
+    @Transactional
+    public PhotoResponseDto updatePhoto(Long userId, Long photoId, PhotoUpdateRequestDto request) {
+        Photo photo = photoRepository.findByIdAndUserId(photoId, userId)
+            .orElseThrow(() -> new AuthException("해당 사진을 찾을 수 없습니다.", "NOT_FOUND"));
+
+        if (request.getMemo() != null) {
+            photo.updateMemo(request.getMemo());
+        }
+        if (request.getFavorite() != null) {
+            photo.updateFavorite(request.getFavorite());
+        }
+
+        log.info("Album photo updated: userId={}, photoId={}", userId, photoId);
+        return PhotoResponseDto.from(photo);
+    }
+
+    /**
+     * 사진 단건 삭제 (소유자만, S3 객체도 정리)
+     */
+    @Transactional
+    public void deletePhoto(Long userId, Long photoId) {
+        Photo photo = photoRepository.findByIdAndUserId(photoId, userId)
+            .orElseThrow(() -> new AuthException("해당 사진을 찾을 수 없습니다.", "NOT_FOUND"));
+
+        deletePhotoObjects(photo);
+        photoRepository.delete(photo);
+        log.info("Album photo deleted: userId={}, photoId={}", userId, photoId);
+    }
+
+    /**
+     * 사진 다중 삭제 (본인 소유만 삭제, 타인/없는 id는 조용히 스킵)
+     */
+    @Transactional
+    public void deletePhotos(Long userId, List<Long> ids) {
+        List<Photo> photos = photoRepository.findByIdInAndUserId(ids, userId);
+
+        for (Photo photo : photos) {
+            deletePhotoObjects(photo);
+        }
+
+        photoRepository.deleteAll(photos);
+        log.info("Album photos bulk deleted: userId={}, requested={}, deleted={}",
+            userId, ids.size(), photos.size());
+    }
+
+    /**
+     * 사진에 연결된 S3 객체(원본 + 썸네일)를 정리한다.
+     * 썸네일이 원본 URL로 폴백된 경우(동일 URL)는 중복 삭제하지 않는다.
+     */
+    private void deletePhotoObjects(Photo photo) {
+        String imageUrl = photo.getImageUrl();
+        String thumbnailUrl = photo.getThumbnailUrl();
+
+        fileUploadService.deleteFile(imageUrl);
+        if (thumbnailUrl != null && !thumbnailUrl.equals(imageUrl)) {
+            fileUploadService.deleteFile(thumbnailUrl);
+        }
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new IllegalArgumentException("이미지 파일만 업로드 가능합니다.");
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("파일 크기는 10MB를 초과할 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/com/min/chalkakserver/config/cache/TestRedisConfig.java
+++ b/src/test/java/com/min/chalkakserver/config/cache/TestRedisConfig.java
@@ -1,0 +1,48 @@
+package com.min.chalkakserver.config.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * test 프로필용 RedisTemplate 설정.
+ *
+ * 운영용 {@link RedisCacheConfig}는 {@code @Profile("!test")}라 테스트에서는 비활성이지만,
+ * PasswordResetService 등이 RedisTemplate<String, Object>를 주입받으므로 빈 자체는 있어야
+ * ApplicationContext가 뜬다. 캐시는 test 프로필의 {@code spring.cache.type=simple}이 그대로
+ * 담당하고, 여기 커넥션 팩토리는 지연 연결이라 실제 Redis 서버 없이도 컨텍스트 로딩에 문제없다.
+ */
+@Configuration
+@Profile("test")
+public class TestRedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        GenericJackson2JsonRedisSerializer valueSerializer = genericJackson2JsonRedisSerializer();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(valueSerializer);
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(valueSerializer);
+        redisTemplate.setDefaultSerializer(valueSerializer);
+
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
+    }
+
+    private GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return new GenericJackson2JsonRedisSerializer(objectMapper);
+    }
+}


### PR DESCRIPTION
### ✨ 새 기능

**네컷 사진첩 API** (`79e2bdf`, PR #13)
- `/api/album/photos` — 사진 업로드·목록·페이지네이션·수정·삭제(단건/벌크)
- 업로드 시 S3 저장 + 썸네일 자동 생성(thumbnailator), 메모·찜·촬영일 관리
- `S3Config`에 커스텀 엔드포인트 옵션 추가 — MinIO 등 S3 호환 스토리지 지원
  (`cloud.aws.s3.endpoint` 미설정 시 기존대로 실제 AWS S3 사용)

**비밀번호 재설정 / 가입 수단 조회** (`ce6169a`, PR #14)
- `POST /api/auth/password/reset/request` — 이메일 인증코드 발송 (Redis TTL 5분)
- `POST /api/auth/password/reset/verify` — 코드 검증 → 재설정 토큰 발급 (TTL 10분)
- `POST /api/auth/password/reset/confirm` — 새 비밀번호 확정 + 기존 refresh token 무효화
- `POST /api/auth/find-provider` — 이메일로 가입한 소셜 provider 조회
- 위 엔드포인트 모두 인증 불필요(public), 이메일 열거 방지를 위해
  계정 존재 여부와 무관하게 동일 응답
- 브루트포스·이메일 폭탄 방지를 위해 `reset/request`·`find-provider`에
  인증 API용 엄격한 rate limit 적용
