### PR TITLE
fix: 자동로그인 로그아웃 결함 + S3 호환 스토리지 엔드포인트 연결

### DIFF
--- a/src/main/java/com/min/chalkakserver/config/RateLimitInterceptor.java
+++ b/src/main/java/com/min/chalkakserver/config/RateLimitInterceptor.java
@@ -67,9 +67,10 @@ public class RateLimitInterceptor implements HandlerInterceptor {
      * 프록시/로드밸런서 뒤에 있는 경우 X-Forwarded-For 헤더 확인
      */
     private String getClientIP(HttpServletRequest request) {
-        // remoteAddr를 기본으로 사용 (X-Forwarded-For 스푸핑 방지)
-        // 프록시/로드밸런서 뒤에서는 Spring의 server.tomcat.remoteip.internal-proxies 설정으로
-        // 신뢰할 수 있는 프록시에서만 X-Forwarded-For를 반영하도록 설정해야 함
+        // remoteAddr만 사용한다 (X-Forwarded-For 직접 파싱 시 스푸핑으로 레이트 리밋 우회 가능).
+        // 프록시 뒤에서는 application-prod.yml의 server.forward-headers-strategy=native 설정으로
+        // Tomcat RemoteIpValve가 신뢰된 내부 프록시의 X-Forwarded-For만 반영해
+        // remoteAddr을 실제 클라이언트 IP로 교체해준다.
         return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
+++ b/src/main/java/com/min/chalkakserver/config/SecurityConfig.java
@@ -1,12 +1,18 @@
 package com.min.chalkakserver.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.min.chalkakserver.dto.ErrorResponse;
 import com.min.chalkakserver.security.jwt.JwtAuthenticationFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -18,6 +24,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -29,6 +37,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ObjectMapper objectMapper;
 
     @Value("${cors.allowed-origins:http://localhost:*,https://localhost:*}")
     private String allowedOrigins;
@@ -76,9 +85,35 @@ public class SecurityConfig {
                 // 나머지 API는 인증 필요
                 .anyRequest().authenticated()
             )
+            .exceptionHandling(exception -> exception
+                // 인증 실패(토큰 없음/만료/서명 불일치)는 401로 응답한다.
+                // 스프링 시큐리티 기본값은 403이라, 클라이언트가 "권한 없음"과 "토큰 갱신 필요"를
+                // 구분할 수 없었다.
+                .authenticationEntryPoint((request, response, authException) ->
+                    writeErrorResponse(request, response, HttpStatus.UNAUTHORIZED,
+                        "Unauthorized", "인증이 필요합니다. 토큰이 없거나 유효하지 않습니다."))
+                // 인증은 되었으나 권한이 부족한 경우만 403으로 응답한다.
+                .accessDeniedHandler((request, response, deniedException) ->
+                    writeErrorResponse(request, response, HttpStatus.FORBIDDEN,
+                        "Forbidden", "이 리소스에 접근할 권한이 없습니다."))
+            )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    /**
+     * 시큐리티 필터 단계의 에러도 컨트롤러 예외와 동일한 ErrorResponse 형태로 응답한다.
+     */
+    private void writeErrorResponse(HttpServletRequest request, HttpServletResponse response,
+                                    HttpStatus status, String error, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        objectMapper.writeValue(
+            response.getWriter(),
+            new ErrorResponse(status.value(), error, message, request.getRequestURI())
+        );
     }
 
     @Bean

--- a/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -360,6 +361,26 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    /**
+     * 권한 부족 (@PreAuthorize 거부 등)
+     * 아래 catch-all 이 먼저 잡으면 500이 되므로 명시적으로 403으로 매핑한다.
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(
+            AccessDeniedException ex, HttpServletRequest request) {
+
+        log.warn("Access denied: {} {}", request.getMethod(), request.getRequestURI());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.FORBIDDEN.value(),
+            "Forbidden",
+            "이 리소스에 접근할 권한이 없습니다.",
+            request.getRequestURI()
+        );
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
 
     /**

--- a/src/main/java/com/min/chalkakserver/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/min/chalkakserver/security/jwt/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.min.chalkakserver.security.jwt;
 import com.min.chalkakserver.entity.User;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -82,14 +83,21 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token);
             return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            log.error("Invalid JWT signature: {}", e.getMessage());
+        } catch (SignatureException | MalformedJwtException e) {
+            // io.jsonwebtoken.security.SignatureException 이어야 한다.
+            // java.lang.SecurityException 으로 잡으면 서명 불일치가 호출자까지 전파되어
+            // /api/auth/refresh 가 401 대신 500을 반환한다.
+            log.warn("Invalid JWT signature: {}", e.getMessage());
         } catch (ExpiredJwtException e) {
-            log.error("Expired JWT token: {}", e.getMessage());
+            // 액세스 토큰 만료는 정상 흐름(클라이언트가 갱신)이므로 에러 레벨로 남기지 않는다.
+            log.debug("Expired JWT token: {}", e.getMessage());
         } catch (UnsupportedJwtException e) {
-            log.error("Unsupported JWT token: {}", e.getMessage());
+            log.warn("Unsupported JWT token: {}", e.getMessage());
+        } catch (JwtException e) {
+            // 위에서 다루지 않은 모든 JJWT 예외도 검증 실패(false)로 수렴시킨다.
+            log.warn("Invalid JWT token: {}", e.getMessage());
         } catch (IllegalArgumentException e) {
-            log.error("JWT claims string is empty: {}", e.getMessage());
+            log.warn("JWT claims string is empty: {}", e.getMessage());
         }
         return false;
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,6 +12,19 @@ spring:
   cache:
     type: redis
 
+# Server - 리버스 프록시(Caddy) 뒤에서 실제 클라이언트 IP를 인식
+# 이 설정이 없으면 request.getRemoteAddr()가 항상 Caddy 컨테이너 IP를 반환해
+# 레이트 리밋 버킷이 전체 사용자에게 하나로 공유된다 (인증 API 전역 10회/분).
+# native 전략은 Tomcat RemoteIpValve를 사용하므로 신뢰된 사설망 프록시
+# (기본값: 10/8, 172.16/12, 192.168/16, 127/8)에서 온 헤더만 반영한다.
+# → 외부에서 X-Forwarded-For를 위조해 레이트 리밋을 우회할 수 없다.
+server:
+  forward-headers-strategy: native
+  tomcat:
+    remoteip:
+      remote-ip-header: X-Forwarded-For
+      protocol-header: X-Forwarded-Proto
+
 # Logging
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,9 @@ cloud:
       static: ${AWS_REGION:ap-northeast-2}
     s3:
       bucket: ${AWS_S3_BUCKET:chalkak-uploads}
+      # S3 호환 스토리지(OCI Object Storage, MinIO 등)용 엔드포인트.
+      # 비어 있으면 실제 AWS S3를 사용한다. 지정 시 S3Config가 path-style로 전환한다.
+      endpoint: ${AWS_S3_ENDPOINT:}
 
 firebase:
   service-account-path: ${FIREBASE_SERVICE_ACCOUNT_PATH:}

--- a/src/test/java/com/min/chalkakserver/config/SecurityResponseStatusIntegrationTest.java
+++ b/src/test/java/com/min/chalkakserver/config/SecurityResponseStatusIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.min.chalkakserver.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 인증 실패 시 응답 상태코드 통합 테스트
+ *
+ * 클라이언트는 401을 받으면 토큰 갱신을 시도하고, 403은 "권한 없음"으로 처리한다.
+ * 만료/무효 토큰이 403으로 내려가면 이 둘을 구분할 수 없으므로 401을 보장한다.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@DisplayName("Security 응답 상태코드 통합 테스트")
+class SecurityResponseStatusIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    @DisplayName("토큰 없이 보호된 API 호출 시 401을 반환한다")
+    void protectedEndpointWithoutToken_returns401() {
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                "/api/auth/me", HttpMethod.GET, null,
+                new org.springframework.core.ParameterizedTypeReference<>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody()).containsKey("timestamp");
+        assertThat(response.getBody()).containsEntry("status", 401);
+        assertThat(response.getBody()).containsEntry("error", "Unauthorized");
+        assertThat(response.getBody()).containsEntry("path", "/api/auth/me");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 보호된 API 호출 시 401을 반환한다")
+    void protectedEndpointWithInvalidToken_returns401() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth("this.is.not.a.valid.jwt");
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/api/auth/me", HttpMethod.GET, new HttpEntity<>(headers), Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("잘못된 서명의 refresh token으로 갱신 요청 시 500이 아니라 401을 반환한다")
+    void refreshWithForeignSignedToken_returns401NotServerError() {
+        // 다른 시크릿으로 서명된 토큰 (구 서버/로컬 환경에서 발급된 토큰)
+        String foreignToken = io.jsonwebtoken.Jwts.builder()
+                .subject("1")
+                .claim("type", "refresh")
+                .issuedAt(new java.util.Date())
+                .expiration(new java.util.Date(System.currentTimeMillis() + 60_000))
+                .signWith(io.jsonwebtoken.security.Keys.hmacShaKeyFor(
+                        "totally-different-secret-key-at-least-32-chars".getBytes()))
+                .compact();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+                "/api/auth/refresh", HttpMethod.POST,
+                new HttpEntity<>(Map.of("refreshToken", foreignToken), headers), Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/test/java/com/min/chalkakserver/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/min/chalkakserver/security/jwt/JwtTokenProviderTest.java
@@ -139,6 +139,18 @@ class JwtTokenProviderTest {
     }
 
     @Test
+    @DisplayName("validateToken - token signed with another secret returns false (must not throw)")
+    void validateToken_wrongSignature_returnsFalse() throws Exception {
+        // 다른 시크릿으로 서명된 토큰 (구 서버/로컬 환경에서 발급된 토큰 등)
+        JwtTokenProvider otherProvider = createProvider(
+                "another-secret-key-must-be-at-least-32-characters", ACCESS_VALIDITY, REFRESH_VALIDITY);
+        String foreignToken = otherProvider.createRefreshToken(buildUser());
+
+        // SignatureException이 전파되면 /api/auth/refresh가 401 대신 500을 반환한다
+        assertThat(jwtTokenProvider.validateToken(foreignToken)).isFalse();
+    }
+
+    @Test
     @DisplayName("validateToken - null token returns false")
     void validateToken_nullToken_returnsFalse() {
         assertThat(jwtTokenProvider.validateToken(null)).isFalse();


### PR DESCRIPTION
## 변경
- **자동로그인 로그아웃 결함 수정** — 인증 응답 결함으로 간헐적 로그아웃 발생하던 문제. Caddy 뒤에서 실제 클라이언트 IP를 인식하도록 `forward-headers-strategy` 추가 (기존엔 레이트 리밋이 전 사용자 공용 버킷이었음)
- **S3 엔드포인트 설정 연결** — `application.yml`에 `cloud.aws.s3.endpoint` 키가 없어 `AWS_S3_ENDPOINT`가 무시됐음. OCI Object Storage 전환에 필요

## 영향
엔티티·리포지토리 변경 없음 → 운영 스키마 변경 없음