### PR TITLE
feat: 프로필 이미지 변경 지원

### DIFF
--- a/src/main/java/com/min/chalkakserver/controller/FileUploadController.java
+++ b/src/main/java/com/min/chalkakserver/controller/FileUploadController.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/uploads")
@@ -18,9 +19,19 @@ public class FileUploadController {
         this.fileUploadService = fileUploadService;
     }
 
+    /** 업로드 대상 디렉터리 화이트리스트 (임의 경로 주입 방지). */
+    private static final Set<String> ALLOWED_TYPES = Set.of("reviews", "profiles");
+
     @PostMapping("/image")
     public ResponseEntity<Map<String, String>> uploadImage(
-            @RequestParam("file") MultipartFile file) throws IOException {
+            @RequestParam("file") MultipartFile file,
+            @RequestParam(value = "type", required = false, defaultValue = "reviews") String type)
+            throws IOException {
+
+        if (!ALLOWED_TYPES.contains(type)) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "지원하지 않는 업로드 타입입니다."));
+        }
 
         // Validate file
         if (file.isEmpty()) {
@@ -40,7 +51,7 @@ public class FileUploadController {
                     .body(Map.of("error", "파일 크기는 10MB를 초과할 수 없습니다."));
         }
 
-        String imageUrl = fileUploadService.uploadFile(file, "reviews");
+        String imageUrl = fileUploadService.uploadFile(file, type);
         return ResponseEntity.ok(Map.of("imageUrl", imageUrl));
     }
 }

--- a/src/main/java/com/min/chalkakserver/dto/auth/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/ProfileUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.min.chalkakserver.dto.auth;
 
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,4 +15,12 @@ public class ProfileUpdateRequestDto {
     
     @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하여야 합니다")
     private String nickname;
+
+    /**
+     * 업로드된 프로필 이미지 URL (`POST /api/uploads/image` 응답값).
+     * null이면 기존 이미지를 유지한다.
+     */
+    @Size(max = 500, message = "프로필 이미지 URL은 500자를 초과할 수 없습니다")
+    @Pattern(regexp = "^https?://.+", message = "프로필 이미지 URL 형식이 올바르지 않습니다")
+    private String profileImageUrl;
 }

--- a/src/main/java/com/min/chalkakserver/entity/User.java
+++ b/src/main/java/com/min/chalkakserver/entity/User.java
@@ -107,6 +107,12 @@ public class User {
         }
     }
 
+    public void updateProfileImageUrl(String profileImageUrl) {
+        if (profileImageUrl != null && !profileImageUrl.isBlank()) {
+            this.profileImageUrl = profileImageUrl;
+        }
+    }
+
     public void updateLastLogin() {
         this.lastLoginAt = LocalDateTime.now();
     }

--- a/src/main/java/com/min/chalkakserver/service/AuthService.java
+++ b/src/main/java/com/min/chalkakserver/service/AuthService.java
@@ -322,7 +322,8 @@ public class AuthService {
             .orElseThrow(() -> new AuthException("User not found"));
 
         user.updateNickname(request.getNickname());
-        
+        user.updateProfileImageUrl(request.getProfileImageUrl());
+
         log.info("User profile updated: userId={}", userId);
         
         return UserResponseDto.from(user);


### PR DESCRIPTION
## 배경

앱 프로필 편집 화면의 프로필 사진 변경이 UI 장식만 있고 미구현 상태입니다(연필 배지/`사진 변경` 텍스트에 탭 핸들러 없음). 서버도 프로필 이미지를 받을 수 없어 앱만으로는 완결되지 않습니다.

- `ProfileUpdateRequestDto`에 `nickname`만 있어 앱이 이미지 URL을 보내도 무시됨
- `AuthService.updateProfile`이 `updateNickname`만 호출

## 변경 사항

- `ProfileUpdateRequestDto`에 `profileImageUrl` 추가 — `@Size(max=500)` + `http(s)` 형식 검증, **null이면 기존 이미지 유지**
- `AuthService.updateProfile`에서 프로필 이미지 반영
- `User.updateProfileImageUrl` 추가 — null/blank는 무시 (기존 `updateNickname`과 동일한 방어 패턴)
- `POST /api/uploads/image`의 업로드 디렉터리를 `type` 파라미터로 선택
  - 화이트리스트 `{reviews, profiles}` — 임의 경로 주입 방지
  - 파라미터 없으면 기본값 `reviews`이므로 **기존 리뷰·게시글 업로드는 그대로 동작**
  - 기존에는 `"reviews"` 하드코딩이라 프로필 사진도 리뷰 폴더에 섞였습니다

## 검증

- `./gradlew compileJava test` — BUILD SUCCESSFUL

## 앱 연동

앱 측 PR과 짝입니다. 이 변경이 배포된 뒤에야 앱에서 프로필 사진이 실제로 저장됩니다.