### PR TITLE
feat: 프로필 이미지 삭제 지원

### DIFF
--- a/src/main/java/com/min/chalkakserver/dto/auth/ProfileUpdateRequestDto.java
+++ b/src/main/java/com/min/chalkakserver/dto/auth/ProfileUpdateRequestDto.java
@@ -23,4 +23,10 @@ public class ProfileUpdateRequestDto {
     @Size(max = 500, message = "프로필 이미지 URL은 500자를 초과할 수 없습니다")
     @Pattern(regexp = "^https?://.+", message = "프로필 이미지 URL 형식이 올바르지 않습니다")
     private String profileImageUrl;
+
+    /**
+     * true면 프로필 이미지를 삭제한다 (profileImageUrl보다 우선).
+     * null 전달은 "변경 없음"이라 삭제와 구분되지 않으므로 별도 플래그로 받는다.
+     */
+    private Boolean removeProfileImage;
 }

--- a/src/main/java/com/min/chalkakserver/entity/User.java
+++ b/src/main/java/com/min/chalkakserver/entity/User.java
@@ -113,6 +113,14 @@ public class User {
         }
     }
 
+    /**
+     * 프로필 이미지를 비운다 (기본 아바타로 되돌림).
+     * null 전달은 "변경 없음"을 뜻하므로, 삭제는 이 메서드로만 가능하다.
+     */
+    public void clearProfileImageUrl() {
+        this.profileImageUrl = null;
+    }
+
     public void updateLastLogin() {
         this.lastLoginAt = LocalDateTime.now();
     }

--- a/src/main/java/com/min/chalkakserver/service/AuthService.java
+++ b/src/main/java/com/min/chalkakserver/service/AuthService.java
@@ -322,7 +322,11 @@ public class AuthService {
             .orElseThrow(() -> new AuthException("User not found"));
 
         user.updateNickname(request.getNickname());
-        user.updateProfileImageUrl(request.getProfileImageUrl());
+        if (Boolean.TRUE.equals(request.getRemoveProfileImage())) {
+            user.clearProfileImageUrl();
+        } else {
+            user.updateProfileImageUrl(request.getProfileImageUrl());
+        }
 
         log.info("User profile updated: userId={}", userId);
         


### PR DESCRIPTION
## 배경

앱에 프로필 사진 **제거** 기능을 붙이려는데 서버가 삭제를 표현할 방법이 없습니다.

`updateProfileImageUrl`은 null/blank를 무시합니다. 이는 의도된 동작으로, `profileImageUrl`을 보내지 않는 요청(닉네임만 수정)이 기존 사진을 지우지 않게 하기 위한 것입니다. 결과적으로 **"변경 없음"과 "삭제"를 구분할 수 없습니다.**

## 변경 사항

- `ProfileUpdateRequestDto`에 `removeProfileImage` (Boolean) 추가
- `User.clearProfileImageUrl()` 추가
- `AuthService.updateProfile`에서 분기:
  ```java
  if (Boolean.TRUE.equals(request.getRemoveProfileImage())) {
      user.clearProfileImageUrl();
  } else {
      user.updateProfileImageUrl(request.getProfileImageUrl());
  }
  ```

빈 문자열을 삭제 신호로 쓰는 방식 대신 명시적 플래그를 택했습니다. 기존 `@Pattern(^https?://.+)` 검증과 충돌하지 않고, 의도가 드러납니다.

## 호환성

- 필드를 보내지 않으면 `null` → 기존과 동일하게 동작합니다. **이미 배포된 앱에 영향 없습니다.**
- DB 스키마 변경 없음 (`users.profile_image_url`은 이미 nullable)

## 검증

- `./gradlew compileJava test` — BUILD SUCCESSFUL