### PR TITLE
fix: 비밀번호 재설정 시 이메일 가입 여부를 먼저 확인

### DIFF
--- a/src/main/java/com/min/chalkakserver/controller/AuthController.java
+++ b/src/main/java/com/min/chalkakserver/controller/AuthController.java
@@ -101,7 +101,9 @@ public class AuthController {
         return ResponseEntity.ok(Map.of("message", "회원 탈퇴가 완료되었습니다."));
     }
 
-    @Operation(summary = "비밀번호 재설정 요청", description = "이메일로 6자리 인증코드 발송 (계정 존재 여부와 무관하게 200 반환)")
+    @Operation(summary = "비밀번호 재설정 요청",
+        description = "이메일 계정이 존재하면 6자리 인증코드 발송. 미가입 이메일은 404, "
+            + "소셜로만 가입된 이메일은 409를 반환한다.")
     @PostMapping("/password/reset/request")
     public ResponseEntity<Map<String, String>> requestPasswordReset(
             @Valid @RequestBody PasswordResetRequestDto request) {

--- a/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
+++ b/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
@@ -42,7 +42,11 @@ public class PasswordResetService {
 
     /**
      * 비밀번호 재설정 요청 - 인증코드 발송
-     * 이메일 열거(enumeration) 방지를 위해 계정 존재 여부와 무관하게 정상 반환한다.
+     *
+     * 이메일 계정이 없으면 발송하지 않고 오류로 알린다. 오지 않는 메일을 기다리게 하는 것보다
+     * 잘못 입력했음을 바로 알려주는 편이 낫다. 계정 열거(enumeration)는 이 방식으로 가능해지지만,
+     * 공개 API인 `POST /api/auth/find-provider`가 이미 같은 정보를 반환하므로 여기서 숨겨도
+     * 실질적인 보호가 되지 않는다.
      */
     public void requestReset(String email) {
         userRepository.findByEmailAndProvider(email, AuthProvider.EMAIL)
@@ -52,7 +56,38 @@ public class PasswordResetService {
                 emailService.sendPasswordResetCode(email, code);
                 // 로컬 테스트용: 실제 SMTP 없이도 코드 확인 가능하도록 로그 출력
                 log.info("[DEV] 비밀번호 재설정 인증코드 생성: email={}, code={}", email, code);
-            }, () -> log.info("비밀번호 재설정 요청 - 존재하지 않는 이메일 계정 (무시): {}", email));
+            }, () -> {
+                throw notRegistered(email);
+            });
+    }
+
+    /**
+     * 이메일 계정이 없을 때의 오류. 소셜로만 가입된 이메일이면 그 사실을 알려준다
+     * (비밀번호가 없는 계정이라 재설정 자체가 성립하지 않는다).
+     */
+    private AuthException notRegistered(String email) {
+        List<String> socialProviders = findProviders(email);
+
+        if (socialProviders.isEmpty()) {
+            log.info("비밀번호 재설정 요청 - 가입되지 않은 이메일: {}", email);
+            return new AuthException("가입되지 않은 이메일입니다. 이메일 주소를 확인해주세요.", "NOT_FOUND");
+        }
+
+        String labels = socialProviders.stream()
+            .map(PasswordResetService::providerLabel)
+            .collect(Collectors.joining(", "));
+        log.info("비밀번호 재설정 요청 - 소셜 가입 계정: email={}, providers={}", email, socialProviders);
+        return new AuthException(
+            labels + "(으)로 가입된 계정입니다. 해당 수단으로 로그인해주세요.", "CONFLICT");
+    }
+
+    private static String providerLabel(String provider) {
+        return switch (provider) {
+            case "KAKAO" -> "카카오";
+            case "NAVER" -> "네이버";
+            case "APPLE" -> "Apple";
+            default -> provider;
+        };
     }
 
     /**

--- a/src/test/java/com/min/chalkakserver/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/PasswordResetServiceTest.java
@@ -1,0 +1,115 @@
+package com.min.chalkakserver.service;
+
+import com.min.chalkakserver.entity.User;
+import com.min.chalkakserver.entity.User.AuthProvider;
+import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.repository.RefreshTokenRepository;
+import com.min.chalkakserver.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PasswordResetService 테스트")
+class PasswordResetServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private EmailService emailService;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private PasswordResetService passwordResetService;
+
+    private static final String EMAIL = "user@test.com";
+
+    private User emailUser() {
+        return User.builder()
+            .email(EMAIL)
+            .nickname("tester")
+            .provider(AuthProvider.EMAIL)
+            .providerId(EMAIL)
+            .role(User.Role.USER)
+            .password("encodedPassword")
+            .build();
+    }
+
+    private User socialUser(AuthProvider provider) {
+        return User.builder()
+            .email(EMAIL)
+            .nickname("tester")
+            .provider(provider)
+            .providerId("social-id")
+            .role(User.Role.USER)
+            .build();
+    }
+
+    @Test
+    @DisplayName("이메일 계정이 있으면 인증코드를 저장하고 메일을 발송한다")
+    void sendsCodeWhenEmailAccountExists() {
+        given(userRepository.findByEmailAndProvider(EMAIL, AuthProvider.EMAIL))
+            .willReturn(Optional.of(emailUser()));
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        passwordResetService.requestReset(EMAIL);
+
+        verify(valueOperations).set(eq("pwreset:code:" + EMAIL), anyString(), any());
+        verify(emailService).sendPasswordResetCode(eq(EMAIL), anyString());
+    }
+
+    @Test
+    @DisplayName("가입되지 않은 이메일이면 NOT_FOUND로 알리고 메일을 보내지 않는다")
+    void rejectsUnregisteredEmail() {
+        given(userRepository.findByEmailAndProvider(EMAIL, AuthProvider.EMAIL))
+            .willReturn(Optional.empty());
+        given(userRepository.findAllByEmail(EMAIL)).willReturn(List.of());
+
+        assertThatThrownBy(() -> passwordResetService.requestReset(EMAIL))
+            .isInstanceOf(AuthException.class)
+            .satisfies(e -> assertThat(((AuthException) e).getCode()).isEqualTo("NOT_FOUND"));
+
+        verify(emailService, never()).sendPasswordResetCode(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("소셜로만 가입된 이메일이면 CONFLICT로 가입 수단을 알려준다")
+    void rejectsSocialOnlyEmail() {
+        given(userRepository.findByEmailAndProvider(EMAIL, AuthProvider.EMAIL))
+            .willReturn(Optional.empty());
+        given(userRepository.findAllByEmail(EMAIL))
+            .willReturn(List.of(socialUser(AuthProvider.KAKAO)));
+
+        assertThatThrownBy(() -> passwordResetService.requestReset(EMAIL))
+            .isInstanceOf(AuthException.class)
+            .hasMessageContaining("카카오")
+            .satisfies(e -> assertThat(((AuthException) e).getCode()).isEqualTo("CONFLICT"));
+
+        verify(emailService, never()).sendPasswordResetCode(anyString(), anyString());
+    }
+}


### PR DESCRIPTION
## 문제

`POST /api/auth/password/reset/request`가 **계정이 없어도 200 + "인증코드가 발송되었습니다. 이메일을 확인해주세요."** 를 반환했습니다. 이메일을 잘못 입력했거나 소셜로만 가입한 사용자는 오지 않는 메일을 계속 기다리게 됩니다.

## 변경 사항

발송 전에 이메일 계정 존재를 확인하고, 없으면 오류로 알립니다.

| 상황 | 이전 | 이후 |
|---|---|---|
| 이메일 계정 있음 | 200 + 발송 | 그대로 |
| 미가입 이메일 | 200 (조용히 무시) | **404** "가입되지 않은 이메일입니다. 이메일 주소를 확인해주세요." |
| 소셜로만 가입 | 200 (조용히 무시) | **409** "카카오(으)로 가입된 계정입니다. 해당 수단으로 로그인해주세요." |

소셜 전용 계정은 비밀번호 자체가 없어 재설정이 성립하지 않으므로, 가입 수단을 알려주는 편이 낫습니다. 여러 수단으로 가입된 경우 전부 나열합니다.

## 계정 열거(enumeration)에 대해

기존 동작은 의도된 열거 방지였고 이 PR은 그것을 포기합니다. 다만 **공개 API인 `POST /api/auth/find-provider`가 이미 동일한 정보를 반환**합니다:

```
$ curl -X POST .../api/auth/find-provider -d '{"email":"..."}'
{"providers":["EMAIL"]}   # 가입됨
{"providers":[]}          # 미가입
```

즉 재설정 엔드포인트에서만 숨겨도 실질적인 보호가 되지 않습니다. 열거 방지를 되살리려면 `find-provider`부터 손봐야 하며, 그건 별도 논의가 필요합니다.

## 앱 영향

앱은 서버의 `message` 필드를 그대로 표시하므로(`auth_service.dart`의 `_getErrorMessage`) **앱 변경 없이** 새 안내가 노출됩니다. `password_reset_screen.dart`의 1단계에서 스낵바로 뜹니다.

## 검증

- `PasswordResetServiceTest` 추가 — 발송 / 미가입(404) / 소셜(409) 3케이스
- `./gradlew test` 전체 통과

## 남은 별건

이 PR 범위 밖이라 손대지 않았습니다.

1. **운영 SMTP 자격증명** — `application-prod.yml`의 "placeholder 자격증명" 주석으로 보아 `MAIL_USERNAME`/`MAIL_PASSWORD`가 실제 값이 아닐 가능성이 큽니다. 이게 원래 "메일이 안 온다"의 원인으로 보입니다.
2. **발송 실패가 사용자에게 안 보임** — `sendPasswordResetCode`가 `@Async` + 예외 삼킴이라 SMTP 실패에도 성공 메시지가 뜹니다.
3. **재설정 코드 평문 로깅** — `PasswordResetService`가 `[DEV]` 접두사로 코드를 로그에 남기는데 프로필 조건이 없어 운영에서도 찍힙니다. 지금은 메일 장애 우회 수단이라 유지했습니다.