### PR TITLE
fix: 인증코드 메일 발송 실패를 사용자에게 알림

### DIFF
--- a/src/main/java/com/min/chalkakserver/exception/EmailSendException.java
+++ b/src/main/java/com/min/chalkakserver/exception/EmailSendException.java
@@ -1,0 +1,14 @@
+package com.min.chalkakserver.exception;
+
+/**
+ * 메일 전송 실패. 발송 결과를 호출자가 알아야 하는 동기 발송 경로에서 사용한다.
+ *
+ * <p>비밀번호 재설정 인증코드처럼 사용자가 메일을 기다리는 경우, 실패를 삼키면
+ * "발송되었습니다"만 보고 오지 않는 메일을 기다리게 된다.
+ */
+public class EmailSendException extends RuntimeException {
+
+    public EmailSendException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/min/chalkakserver/exception/GlobalExceptionHandler.java
@@ -160,6 +160,10 @@ public class GlobalExceptionHandler {
                 status = HttpStatus.NOT_FOUND;
                 error = "Not Found";
                 break;
+            case "SERVICE_UNAVAILABLE":
+                status = HttpStatus.SERVICE_UNAVAILABLE;
+                error = "Service Unavailable";
+                break;
             default:
                 status = HttpStatus.UNAUTHORIZED;
                 error = "Unauthorized";

--- a/src/main/java/com/min/chalkakserver/service/EmailService.java
+++ b/src/main/java/com/min/chalkakserver/service/EmailService.java
@@ -1,6 +1,8 @@
 package com.min.chalkakserver.service;
 
 import com.min.chalkakserver.dto.PhotoBoothReportDto;
+import com.min.chalkakserver.exception.EmailSendException;
+import jakarta.annotation.PostConstruct;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.web.util.HtmlUtils;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +27,38 @@ public class EmailService {
 
     @Value("${app.admin-email}")
     private String adminEmail;
+
+    @Value("${spring.mail.username:}")
+    private String mailUsername;
+
+    @Value("${spring.mail.password:}")
+    private String mailPassword;
+
+    /** .env.example의 예시 값. 이 값이 그대로 들어와 있으면 설정이 안 된 것이다. */
+    private static final Set<String> PLACEHOLDERS =
+        Set.of("your_email@gmail.com", "your_app_password_here", "changeme");
+
+    /**
+     * 메일 자격증명 누락을 시작 시점에 드러낸다.
+     *
+     * <p>앱을 죽이지는 않는다. 메일은 일부 기능(제보·비밀번호 재설정)만 쓰므로,
+     * 이것 때문에 API 전체를 내리는 편이 더 나쁘다. 대신 실패를 조용히 넘기지 않도록
+     * ERROR로 남긴다.
+     */
+    @PostConstruct
+    void warnIfMailNotConfigured() {
+        boolean missing = isUnset(mailUsername) || isUnset(mailPassword);
+        if (missing) {
+            log.error(
+                "메일 자격증명이 설정되지 않았습니다 (MAIL_USERNAME/MAIL_PASSWORD). "
+                    + "제보 메일과 비밀번호 재설정 인증코드가 발송되지 않습니다. "
+                    + "MAIL_PASSWORD는 Gmail 계정 비밀번호가 아니라 앱 비밀번호여야 합니다.");
+        }
+    }
+
+    private static boolean isUnset(String value) {
+        return value == null || value.isBlank() || PLACEHOLDERS.contains(value.trim());
+    }
 
     @Async
     public void sendPhotoBoothReport(PhotoBoothReportDto reportDto) {
@@ -43,7 +78,10 @@ public class EmailService {
         }
     }
 
-    @Async
+    /**
+     * 비밀번호 재설정 인증코드 발송. 사용자가 결과를 기다리므로 동기로 보내고
+     * 실패는 {@link EmailSendException}으로 알린다 (@Async로 두면 실패가 묻힌다).
+     */
     public void sendPasswordResetCode(String toEmail, String code) {
         try {
             MimeMessage message = mailSender.createMimeMessage();
@@ -56,8 +94,8 @@ public class EmailService {
             mailSender.send(message);
             log.info("비밀번호 재설정 인증코드 전송 성공: {}", escapeForLog(toEmail));
         } catch (MessagingException | RuntimeException e) {
-            // @Async 메서드에서는 예외를 던져도 호출자에게 전달되지 않으므로 로깅만 수행
             log.error("비밀번호 재설정 인증코드 전송 실패: {}", escapeForLog(toEmail), e);
+            throw new EmailSendException("비밀번호 재설정 인증코드 전송 실패", e);
         }
     }
 

--- a/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
+++ b/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
@@ -3,6 +3,7 @@ package com.min.chalkakserver.service;
 import com.min.chalkakserver.entity.User;
 import com.min.chalkakserver.entity.User.AuthProvider;
 import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.exception.EmailSendException;
 import com.min.chalkakserver.repository.RefreshTokenRepository;
 import com.min.chalkakserver.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +53,17 @@ public class PasswordResetService {
         userRepository.findByEmailAndProvider(email, AuthProvider.EMAIL)
             .ifPresentOrElse(user -> {
                 String code = generateCode();
+
+                // 발송에 성공한 코드만 저장한다. 먼저 저장하면 메일이 실패해도
+                // 쓸 수 없는 코드가 5분간 남는다.
+                try {
+                    emailService.sendPasswordResetCode(email, code);
+                } catch (EmailSendException e) {
+                    throw new AuthException(
+                        "인증코드 발송에 실패했습니다. 잠시 후 다시 시도해주세요.", "SERVICE_UNAVAILABLE");
+                }
+
                 redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
-                emailService.sendPasswordResetCode(email, code);
                 // 로컬 테스트용: 실제 SMTP 없이도 코드 확인 가능하도록 로그 출력
                 log.info("[DEV] 비밀번호 재설정 인증코드 생성: email={}, code={}", email, code);
             }, () -> {

--- a/src/test/java/com/min/chalkakserver/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/PasswordResetServiceTest.java
@@ -3,6 +3,7 @@ package com.min.chalkakserver.service;
 import com.min.chalkakserver.entity.User;
 import com.min.chalkakserver.entity.User.AuthProvider;
 import com.min.chalkakserver.exception.AuthException;
+import com.min.chalkakserver.exception.EmailSendException;
 import com.min.chalkakserver.repository.RefreshTokenRepository;
 import com.min.chalkakserver.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -81,6 +83,23 @@ class PasswordResetServiceTest {
 
         verify(valueOperations).set(eq("pwreset:code:" + EMAIL), anyString(), any());
         verify(emailService).sendPasswordResetCode(eq(EMAIL), anyString());
+    }
+
+    @Test
+    @DisplayName("메일 발송이 실패하면 503으로 알리고 인증코드를 저장하지 않는다")
+    void reportsFailureWhenMailSendFails() {
+        given(userRepository.findByEmailAndProvider(EMAIL, AuthProvider.EMAIL))
+            .willReturn(Optional.of(emailUser()));
+        willThrow(new EmailSendException("boom", new RuntimeException()))
+            .given(emailService).sendPasswordResetCode(eq(EMAIL), anyString());
+
+        assertThatThrownBy(() -> passwordResetService.requestReset(EMAIL))
+            .isInstanceOf(AuthException.class)
+            .satisfies(
+                e -> assertThat(((AuthException) e).getCode()).isEqualTo("SERVICE_UNAVAILABLE"));
+
+        // 쓸 수 없는 코드가 남지 않아야 한다.
+        verify(redisTemplate, never()).opsForValue();
     }
 
     @Test


### PR DESCRIPTION
## 문제

`sendPasswordResetCode`가 `@Async` + 예외 삼킴이라, SMTP가 실패해도 앱에는 **"인증코드가 발송되었습니다. 이메일을 확인해주세요."** 가 떴습니다. 실제 운영에서 요청을 보내보면 **0.17초에 200**이 돌아오는데, SMTP 연결 타임아웃이 5초로 설정된 걸 보면 발송 결과를 기다리지도 않았다는 뜻입니다. 사용자는 오지 않는 메일을 계속 기다리게 됩니다.

## 변경 사항

**1. 발송 실패를 응답에 반영**

- `sendPasswordResetCode`를 동기로 전환하고, 실패 시 `EmailSendException`을 던집니다
- 재설정 요청은 이를 받아 **503 "인증코드 발송에 실패했습니다. 잠시 후 다시 시도해주세요."** 로 응답합니다
- `AuthException` 코드 `SERVICE_UNAVAILABLE` → 503 매핑 추가
- 제보 메일(`sendPhotoBoothReport`)은 관리자용 fire-and-forget이라 `@Async` 유지

> 트레이드오프: 재설정 요청이 SMTP 응답을 기다리므로 응답 시간이 늘어납니다. `application.yml`의 connection/read/write 타임아웃이 각 5초라 최악의 경우 수 초입니다. 사용자가 결과를 알아야 하는 요청이므로 이 지연은 감수할 만하다고 봤습니다.

**2. 쓸 수 없는 코드가 남지 않도록 순서 변경**

기존에는 Redis에 코드를 저장한 **뒤** 발송했습니다. 발송이 실패하면 사용할 수 없는 코드가 5분간 남습니다. 발송 성공 후에 저장하도록 순서를 바꿨습니다.

**3. 메일 자격증명 미설정을 시작 시점에 노출**

`MAIL_USERNAME`/`MAIL_PASSWORD`가 비어 있거나 `.env.example`의 예시 값(`your_email@gmail.com` 등)이면 `@PostConstruct`에서 ERROR 로그를 남깁니다.

```
메일 자격증명이 설정되지 않았습니다 (MAIL_USERNAME/MAIL_PASSWORD).
제보 메일과 비밀번호 재설정 인증코드가 발송되지 않습니다.
MAIL_PASSWORD는 Gmail 계정 비밀번호가 아니라 앱 비밀번호여야 합니다.
```

앱을 죽이지는 않습니다. 메일은 제보·비밀번호 재설정에만 쓰이므로, 이것 때문에 API 전체를 내리는 편이 더 나쁩니다. `application-prod.yml`이 mail health 지표를 "placeholder 자격증명" 때문에 끈 상태라, 이 로그가 실제 원인 확인 수단이 됩니다.

## 앱 영향

앱은 서버의 `message`를 그대로 표시하므로(`auth_service.dart`의 `_getErrorMessage`) **앱 변경 없이** 503 안내가 재설정 1단계 스낵바에 뜹니다.

## 검증

- `./gradlew test` 전체 통과
- 발송 실패 케이스 테스트 추가 — 503 코드 확인 + **Redis에 코드가 저장되지 않음** 검증

## 남은 것

**운영 `MAIL_USERNAME`/`MAIL_PASSWORD` 설정** — 이 PR은 실패를 드러낼 뿐 메일을 되살리지 않습니다. 운영 compose와 `.env`는 서버(`/opt/chalkak/`)에만 있어 레포에서 고칠 수 없습니다. 배포 후 컨테이너 로그에 위 ERROR가 찍히면 자격증명 미설정이 확정됩니다.