### PR TITLE
fix: 비밀번호 재설정 인증코드를 운영 로그에 남기지 않음

### DIFF
--- a/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
+++ b/src/main/java/com/min/chalkakserver/service/PasswordResetService.java
@@ -8,6 +8,8 @@ import com.min.chalkakserver.repository.RefreshTokenRepository;
 import com.min.chalkakserver.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -38,6 +40,7 @@ public class PasswordResetService {
     private final EmailService emailService;
     private final PasswordEncoder passwordEncoder;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final Environment environment;
 
     private final SecureRandom secureRandom = new SecureRandom();
 
@@ -64,8 +67,12 @@ public class PasswordResetService {
                 }
 
                 redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
-                // 로컬 테스트용: 실제 SMTP 없이도 코드 확인 가능하도록 로그 출력
-                log.info("[DEV] 비밀번호 재설정 인증코드 생성: email={}, code={}", email, code);
+
+                // 인증코드는 비밀번호와 같은 등급의 비밀이다. 로그에 남기면 로그 열람 권한만으로
+                // 임의 계정의 비밀번호를 재설정할 수 있으므로, SMTP가 없는 local 프로파일에서만 남긴다.
+                if (environment.acceptsProfiles(Profiles.of("local"))) {
+                    log.info("[LOCAL] 비밀번호 재설정 인증코드: email={}, code={}", email, code);
+                }
             }, () -> {
                 throw notRegistered(email);
             });

--- a/src/test/java/com/min/chalkakserver/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/min/chalkakserver/service/PasswordResetServiceTest.java
@@ -1,5 +1,8 @@
 package com.min.chalkakserver.service;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.min.chalkakserver.entity.User;
 import com.min.chalkakserver.entity.User.AuthProvider;
 import com.min.chalkakserver.exception.AuthException;
@@ -12,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -45,6 +50,8 @@ class PasswordResetServiceTest {
     private PasswordEncoder passwordEncoder;
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private Environment environment;
 
     @InjectMocks
     private PasswordResetService passwordResetService;
@@ -83,6 +90,30 @@ class PasswordResetServiceTest {
 
         verify(valueOperations).set(eq("pwreset:code:" + EMAIL), anyString(), any());
         verify(emailService).sendPasswordResetCode(eq(EMAIL), anyString());
+    }
+
+    @Test
+    @DisplayName("local 프로파일이 아니면 인증코드를 로그에 남기지 않는다")
+    void neverLogsCodeOutsideLocalProfile() {
+        given(userRepository.findByEmailAndProvider(EMAIL, AuthProvider.EMAIL))
+            .willReturn(Optional.of(emailUser()));
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(PasswordResetService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            // environment 목은 acceptsProfiles에 false를 반환한다 (= 운영/개발 프로파일).
+            passwordResetService.requestReset(EMAIL);
+        } finally {
+            logger.detachAppender(appender);
+        }
+
+        assertThat(appender.list)
+            .extracting(ILoggingEvent::getFormattedMessage)
+            .noneMatch(message -> message.contains("code="));
     }
 
     @Test


### PR DESCRIPTION
## 문제

`PasswordResetService`가 재설정 인증코드를 평문으로 로깅했습니다.

```java
// 로컬 테스트용: 실제 SMTP 없이도 코드 확인 가능하도록 로그 출력
log.info("[DEV] 비밀번호 재설정 인증코드 생성: email={}, code={}", email, code);
```

`[DEV]` 접두사가 붙어 있지만 **프로필 조건이 없어 운영에서도 항상 실행**됐습니다. 실제 운영 로그에서 확인된 형태:

```
[DEV] 비밀번호 재설정 인증코드 생성: email=***@naver.com, code=******
```

인증코드는 비밀번호와 같은 등급의 비밀입니다. 로그 열람 권한만 있으면 임의의 EMAIL 계정에 재설정을 요청하고 로그에서 코드를 읽어 비밀번호를 바꿀 수 있었습니다. 메일 장애 기간에는 이 로그가 유일한 우회 수단이라 유지했지만, 발송이 정상화되어 제거합니다.

## 변경 사항

- SMTP 자격증명이 없는 **`local` 프로파일에서만** 코드를 남깁니다 (`Environment.acceptsProfiles`)
- 그 외 프로파일에서는 코드가 로그에 등장하지 않습니다

로컬 개발 편의는 유지됩니다 — `application-local.yml`이 더미 메일 값을 쓰므로 실제 발송이 안 되고, 그 환경에서만 코드를 확인할 수 있습니다.

## 검증

Logback `ListAppender`로 실제 로그 출력을 캡처해, local이 아닌 프로파일에서 `code=`가 **한 줄도 남지 않음**을 검증하는 테스트를 추가했습니다. 주석으로만 막지 않고 회귀를 테스트로 고정했습니다.

`./gradlew test` 전체 통과.

## 함께 적용되는 서버 설정 변경

이 PR이 배포되면 `app` 컨테이너가 재생성되면서, 서버 `.env.production`에 미리 반영해 둔 **`ADMIN_EMAIL` 변경(`ehdals45454@gmail.com` → `chalkak0ffica1@gmail.com`)** 도 함께 적용됩니다. 재시작을 두 번 하지 않으려고 묶었습니다.